### PR TITLE
Add opposite checkbox and loading states to photo toolbar

### DIFF
--- a/src/components/canvas/PhotoBase.vue
+++ b/src/components/canvas/PhotoBase.vue
@@ -225,7 +225,7 @@ onMounted(() => {
 }
 
 .expansion-type-select {
-  flex: 2;
+  flex: 1.5;
 }
 
 .opposite-checkbox {

--- a/src/components/canvas/PhotoBase.vue
+++ b/src/components/canvas/PhotoBase.vue
@@ -222,6 +222,8 @@ onMounted(() => {
   display: flex;
   gap: var(--spacing-sm);
   width: 100%;
+  height: 32px;
+  align-items: center;
 }
 
 .expansion-type-select {

--- a/src/components/canvas/PhotoBase.vue
+++ b/src/components/canvas/PhotoBase.vue
@@ -51,7 +51,7 @@
 </template>
 
 <script setup>
-import { NSelect } from "naive-ui";
+import { NSelect, NCheckbox } from "naive-ui";
 import { nextTick, onMounted, ref, watch } from "vue";
 import { useCanvasStore, expansionTypeOptions } from "@/stores/canvas.js";
 import { useTagDisplay } from "@/composables/canvas/useTagsDisplay";

--- a/src/components/canvas/PhotoBase.vue
+++ b/src/components/canvas/PhotoBase.vue
@@ -216,7 +216,6 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-sm);
-  align-self: flex-end;
 }
 
 .base-image-header {

--- a/src/components/canvas/PhotoBase.vue
+++ b/src/components/canvas/PhotoBase.vue
@@ -219,7 +219,20 @@ onMounted(() => {
 }
 
 .base-image-header {
+  display: flex;
+  gap: var(--spacing-sm);
   width: 100%;
+}
+
+.expansion-type-select {
+  flex: 2;
+}
+
+.opposite-checkbox {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  font-size: var(--font-size-sm);
 }
 
 .base-image-container {

--- a/src/components/canvas/PhotoBase.vue
+++ b/src/components/canvas/PhotoBase.vue
@@ -216,6 +216,7 @@ onMounted(() => {
   display: flex;
   flex-direction: column;
   gap: var(--spacing-sm);
+  align-self: flex-end;
 }
 
 .base-image-header {

--- a/src/components/canvas/PhotoBase.vue
+++ b/src/components/canvas/PhotoBase.vue
@@ -243,7 +243,6 @@ onMounted(() => {
   border-radius: var(--radius-md);
   overflow: hidden;
   border: 2px solid var(--border-color);
-  margin-top: auto;
 }
 
 .base-image-overlay {

--- a/src/components/canvas/PhotoBase.vue
+++ b/src/components/canvas/PhotoBase.vue
@@ -222,7 +222,6 @@ onMounted(() => {
   display: flex;
   gap: var(--spacing-sm);
   width: 100%;
-  height: 32px;
   align-items: center;
 }
 

--- a/src/components/canvas/PhotoBase.vue
+++ b/src/components/canvas/PhotoBase.vue
@@ -7,7 +7,15 @@
         :options="expansionTypeOptions"
         placeholder="Search type"
         label-field="label"
+        class="expansion-type-select"
       />
+      <n-checkbox
+        v-model:checked="toolbarState.expansion.opposite"
+        size="small"
+        class="opposite-checkbox"
+      >
+        Opposite
+      </n-checkbox>
     </div>
     <div class="base-image-container">
       <div
@@ -76,7 +84,7 @@ const loadPhotosFromToolbar = async () => {
     100,
     basePosition,
     props.toolbarState.expansion.opposite,
-    props.toolbarState.expansion.inverted
+    props.toolbarState.expansion.inverted,
   );
 
   await nextTick();
@@ -105,7 +113,7 @@ const loadPhotosFromSelections = debounce(async () => {
     100,
     basePosition,
     props.toolbarState.expansion.opposite,
-    props.toolbarState.expansion.inverted
+    props.toolbarState.expansion.inverted,
   );
 
   await nextTick();
@@ -147,7 +155,7 @@ watch(
       loadPhotosFromSelections();
     }
   },
-  { deep: true }
+  { deep: true },
 );
 
 watch(
@@ -159,7 +167,7 @@ watch(
     if (!photo || skip) return;
     await loadPhotosFromToolbar();
   },
-  { immediate: true }
+  { immediate: true },
 );
 
 watch(
@@ -177,7 +185,7 @@ watch(
     } else {
       loadPhotosFromToolbar();
     }
-  }
+  },
 );
 
 watch(
@@ -186,7 +194,7 @@ watch(
     if (newCriteria === "tags" || newCriteria === "composition") {
       emit("photos-generated", []);
     }
-  }
+  },
 );
 
 function resetAllTags() {

--- a/src/components/canvas/PhotoBase.vue
+++ b/src/components/canvas/PhotoBase.vue
@@ -242,6 +242,7 @@ onMounted(() => {
   border-radius: var(--radius-md);
   overflow: hidden;
   border: 2px solid var(--border-color);
+  margin-top: auto;
 }
 
 .base-image-overlay {

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -143,6 +143,10 @@ const handleHorizontalScroll = (e: WheelEvent) => {
   e.preventDefault();
   scrollContainer.value.scrollLeft += e.deltaY;
 };
+
+const handleLoadingState = (isLoading: boolean) => {
+  emit("loading", isLoading);
+};
 </script>
 
 <style scoped>

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -63,7 +63,7 @@
 
 <script setup lang="ts">
 import { ref, nextTick } from "vue";
-import { NIcon } from "naive-ui";
+import { NIcon, NSkeleton } from "naive-ui";
 import PhotoBase from "./PhotoBase.vue";
 import PhotoCard from "../PhotoCard.vue";
 

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -92,6 +92,7 @@ interface Emits {
 
 const props = withDefaults(defineProps<Props>(), {
   isVisible: false,
+  isLoading: false,
   baseImage: () => ({
     id: "base-1",
     url: "https://images.unsplash.com/photo-1506905925346-21bda4d32df4?w=400&h=400&fit=crop",

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -88,6 +88,7 @@ interface Emits {
   (e: "close"): void;
   (e: "photos-selected", photoIds: string[]): void;
   (e: "search-type-changed", searchType: string): void;
+  (e: "loading", isLoading: boolean): void;
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -232,22 +232,18 @@ const handleLoadingState = (isLoading: boolean) => {
   scrollbar-color: rgba(0, 0, 0, 0.4) transparent;
 }
 
-.related-photos-scroll:hover {
-  scrollbar-color: rgba(0, 0, 0, 0.4) transparent;
-}
-
 .related-photos-scroll::-webkit-scrollbar {
   height: 8px;
-  background: transparent;
+  background: rgba(0, 0, 0, 0.1);
 }
 
 .related-photos-scroll::-webkit-scrollbar-thumb {
-  background: transparent;
+  background: rgba(0, 0, 0, 0.4);
   border-radius: 4px;
 }
 
-.related-photos-scroll:hover::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.4);
+.related-photos-scroll::-webkit-scrollbar-thumb:hover {
+  background: rgba(0, 0, 0, 0.6);
 }
 
 .related-photos-grid {

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -293,6 +293,11 @@ const handleHorizontalScroll = (e: WheelEvent) => {
     width: 120px;
     height: 120px;
   }
+
+  .related-photo-skeleton {
+    width: 120px;
+    height: 120px;
+  }
 }
 
 @media (max-width: 480px) {

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -21,14 +21,27 @@
           ref="scrollContainer"
         >
           <div class="related-photos-grid">
-            <PhotoCard
-              v-for="photo in relatedPhotos"
-              :key="photo.id"
-              :photo="photo"
-              :selected="selectedPhotos.includes(photo.id)"
-              @select="togglePhotoSelection"
-              @info="onPhotoInfo"
-            />
+            <!-- Show skeletons when loading -->
+            <template v-if="props.isLoading">
+              <div
+                v-for="n in 6"
+                :key="`skeleton-${n}`"
+                class="related-photo-skeleton"
+              >
+                <n-skeleton height="100%" />
+              </div>
+            </template>
+            <!-- Show actual photos when loaded -->
+            <template v-else>
+              <PhotoCard
+                v-for="photo in relatedPhotos"
+                :key="photo.id"
+                :photo="photo"
+                :selected="selectedPhotos.includes(photo.id)"
+                @select="togglePhotoSelection"
+                @info="onPhotoInfo"
+              />
+            </template>
           </div>
         </div>
       </div>

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -258,6 +258,15 @@ const handleHorizontalScroll = (e: WheelEvent) => {
   height: 160px;
 }
 
+.related-photo-skeleton {
+  flex-shrink: 0;
+  width: 160px;
+  height: 160px;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background-color: var(--bg-surface);
+}
+
 @media (max-width: 768px) {
   .related-photos-toolbar {
     height: 200px;

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -233,17 +233,18 @@ const handleLoadingState = (isLoading: boolean) => {
 }
 
 .related-photos-scroll::-webkit-scrollbar {
-  height: 8px;
-  background: rgba(0, 0, 0, 0.1);
+  height: 12px;
+  background: rgba(255, 255, 255, 0.1);
 }
 
 .related-photos-scroll::-webkit-scrollbar-thumb {
-  background: rgba(0, 0, 0, 0.4);
-  border-radius: 4px;
+  background: rgba(255, 255, 255, 0.3);
+  border-radius: 6px;
+  border: 1px solid rgba(255, 255, 255, 0.1);
 }
 
 .related-photos-scroll::-webkit-scrollbar-thumb:hover {
-  background: rgba(0, 0, 0, 0.6);
+  background: rgba(255, 255, 255, 0.5);
 }
 
 .related-photos-grid {

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -229,7 +229,7 @@ const handleLoadingState = (isLoading: boolean) => {
   overflow-y: hidden;
   padding-bottom: var(--spacing-xs);
   scrollbar-width: thin; /* Firefox */
-  scrollbar-color: rgba(0, 0, 0, 0.4) transparent;
+  scrollbar-color: rgba(255, 255, 255, 0.3) rgba(255, 255, 255, 0.1);
 }
 
 .related-photos-scroll::-webkit-scrollbar {

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -68,6 +68,7 @@ interface Props {
   isVisible: boolean;
   baseImage?: Photo;
   toolbarState: Object;
+  isLoading?: boolean;
 }
 
 interface Emits {

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -6,7 +6,7 @@
         :baseImage="props.baseImage"
         :toolbar-state="toolbarState"
         @photos-generated="handleGeneratedPhotos"
-        @loading="(val) => {}"
+        @loading="handleLoadingState"
       />
 
       <!-- Related Photos Section (Scrollable Right) -->

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -229,7 +229,7 @@ const handleLoadingState = (isLoading: boolean) => {
   overflow-y: hidden;
   padding-bottom: var(--spacing-xs);
   scrollbar-width: thin; /* Firefox */
-  scrollbar-color: transparent transparent;
+  scrollbar-color: rgba(0, 0, 0, 0.4) transparent;
 }
 
 .related-photos-scroll:hover {

--- a/src/components/canvas/RelatedPhotosToolbar.vue
+++ b/src/components/canvas/RelatedPhotosToolbar.vue
@@ -322,6 +322,11 @@ const handleHorizontalScroll = (e: WheelEvent) => {
     height: 100px;
   }
 
+  .related-photo-skeleton {
+    width: 100px;
+    height: 100px;
+  }
+
   .related-photos-header {
     flex-direction: column;
     align-items: flex-start;

--- a/src/views/CanvasView.vue
+++ b/src/views/CanvasView.vue
@@ -310,7 +310,7 @@
               </template>
               <span v-if="canvasModeIsExpanded" class="button-text">{{
                 expansionTypeOptions.find(
-                  (opt) => opt.value == toolbarState.expansion.type
+                  (opt) => opt.value == toolbarState.expansion.type,
                 ).label
               }}</span>
               <n-icon v-if="canvasModeIsExpanded" class="dropdown-arrow">
@@ -482,6 +482,7 @@ const showRelatedPhotos = ref(false);
 const showPhotosDialog = ref(false);
 const showTrashDialog = ref(false);
 const selectedPhotoForToolbar = ref(null);
+const isLoadingRelatedPhotos = ref(false);
 
 // Expandable dropdown state
 const canvasModeIsExpanded = ref(false);
@@ -569,7 +570,7 @@ const handleAddPhotosToCanvas = async (event) => {
     basePosition,
     toolbarState.value.expansion.opposite,
     toolbarState.value.expansion.inverted,
-    true
+    true,
   );
 
   if (
@@ -583,7 +584,7 @@ const handleAddPhotosToCanvas = async (event) => {
       position,
       offsetX,
       offsetY,
-      toolbarState.value.photoOptions.spreadMode
+      toolbarState.value.photoOptions.spreadMode,
     );
   } else {
     animatePhotoGroupExplosion(photoRefs, photos, basePosition, position);
@@ -638,7 +639,7 @@ const fitStageToPhotos = (extraPaddingRatio = 0.1) => {
       minY: Infinity,
       maxX: -Infinity,
       maxY: -Infinity,
-    }
+    },
   );
 
   // Añadir padding adicional
@@ -654,7 +655,7 @@ const fitStageToPhotos = (extraPaddingRatio = 0.1) => {
   const targetZoom = Math.min(
     containerWidth / photosWidth,
     containerHeight / photosHeight,
-    2
+    2,
   );
 
   const targetX =
@@ -785,7 +786,7 @@ watch(
       }
     });
   },
-  { immediate: true }
+  { immediate: true },
 );
 
 onMounted(() => {
@@ -1020,7 +1021,10 @@ onUnmounted(() => {
   align-items: center;
   line-height: 90px;
 
-  transition: background-color 0.2s, border-color 0.2s, transform 0.2s ease;
+  transition:
+    background-color 0.2s,
+    border-color 0.2s,
+    transform 0.2s ease;
   transform: rotate(0deg) scale(1);
   align-content: center;
   justify-content: center;
@@ -1031,7 +1035,9 @@ onUnmounted(() => {
   background-color: rgba(255, 0, 0, 0.25);
   border-color: darkred;
   transform: rotate(8deg) scale(1.08);
-  transition: transform 0.2s ease, background-color 0.2s ease,
+  transition:
+    transform 0.2s ease,
+    background-color 0.2s ease,
     border-color 0.2s ease;
 }
 </style>

--- a/src/views/CanvasView.vue
+++ b/src/views/CanvasView.vue
@@ -812,8 +812,17 @@ const handleResize = () => {
   }
 };
 
+// Close config menu function
+const closeConfigMenu = () => {
+  showConfigMenu.value = false;
+};
+
 // Click outside handler to close dropdown only
 const handleClickOutside = (event) => {
+  // Close config menu if clicking outside
+  if (configMenuRef.value && !configMenuRef.value.contains(event.target)) {
+    closeConfigMenu();
+  }
   const target = event.target;
 
   if (

--- a/src/views/CanvasView.vue
+++ b/src/views/CanvasView.vue
@@ -208,6 +208,7 @@
       v-if="showRelatedPhotos"
       :base-image="selectedPhotoForToolbar"
       :is-visible="showRelatedPhotos"
+      :is-loading="isLoadingRelatedPhotos"
       :toolbar-state="toolbarState"
       @close="hideRelatedPhotos"
       @photos-selected="onPhotosSelected"

--- a/src/views/CanvasView.vue
+++ b/src/views/CanvasView.vue
@@ -1030,6 +1030,69 @@ onUnmounted(() => {
   height: 16px;
 }
 
+/* Config Menu Styles */
+.config-menu-container {
+  position: relative;
+}
+
+.config-dropdown {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  background: var(--bg-container, rgba(30, 30, 30, 0.95));
+  backdrop-filter: blur(12px);
+  border-radius: 12px;
+  border: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  z-index: 1000;
+  margin-top: 8px;
+  min-width: 280px;
+  animation: slideDown 0.2s ease-out;
+}
+
+.config-section {
+  padding: var(--spacing-lg);
+}
+
+.config-section:not(:last-child) {
+  border-bottom: 1px solid var(--border-color, rgba(255, 255, 255, 0.1));
+}
+
+.section-title {
+  font-size: var(--font-size-md);
+  font-weight: var(--font-weight-semibold);
+  color: var(--text-primary);
+  margin: 0 0 var(--spacing-md) 0;
+}
+
+.config-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--spacing-md);
+}
+
+.config-item:last-child {
+  margin-bottom: 0;
+}
+
+.config-label {
+  font-size: var(--font-size-sm);
+  color: var(--text-secondary);
+  font-weight: var(--font-weight-medium);
+}
+
+.layout-pills {
+  display: flex;
+  gap: var(--spacing-xs);
+}
+
+.layout-pill {
+  padding: 4px 8px !important;
+  font-size: var(--font-size-xs) !important;
+  border-radius: var(--radius-sm) !important;
+}
+
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .canvas-controls {

--- a/src/views/CanvasView.vue
+++ b/src/views/CanvasView.vue
@@ -693,8 +693,7 @@ const fitStageToPhotos = (extraPaddingRatio = 0.1) => {
 };
 
 const openConfig = () => {
-  console.log("Open config");
-  // TODO: Implement config dialog
+  showConfigMenu.value = !showConfigMenu.value;
 };
 
 const toggleInteractionMode = () => {

--- a/src/views/CanvasView.vue
+++ b/src/views/CanvasView.vue
@@ -211,6 +211,7 @@
       :is-loading="isLoadingRelatedPhotos"
       :toolbar-state="toolbarState"
       @close="hideRelatedPhotos"
+      @loading="isLoadingRelatedPhotos = $event"
       @photos-selected="onPhotosSelected"
       @search-type-changed="onSearchTypeChanged"
     />

--- a/src/views/CanvasView.vue
+++ b/src/views/CanvasView.vue
@@ -490,6 +490,10 @@ const isLoadingRelatedPhotos = ref(false);
 const canvasModeIsExpanded = ref(false);
 const isDropdownOpen = ref(false);
 
+// Config menu state
+const showConfigMenu = ref(false);
+const configMenuRef = ref(null);
+
 // Dropdown options with SVG icons
 
 const secondaryColor = getComputedStyle(document.documentElement)

--- a/src/views/CanvasView.vue
+++ b/src/views/CanvasView.vue
@@ -490,7 +490,14 @@ import { useCanvasStore, expansionTypeOptions } from "@/stores/canvas.js";
 // import PhotoDetectionAreas from "@/components/canvas/PhotoControls/PhotoDetectionAreas.vue";
 import { usePhotosStore } from "@/stores/photos";
 import { ref, onMounted, onUnmounted, computed, h, watch } from "vue";
-import { NButton, NButtonGroup, NIcon, NSpace } from "naive-ui";
+import {
+  NButton,
+  NButtonGroup,
+  NIcon,
+  NSpace,
+  NSwitch,
+  NInputNumber,
+} from "naive-ui";
 import { storeToRefs } from "pinia";
 import PhotosDialog from "@/components/canvas/PhotosDialog.vue";
 import ExpandPhotoButtons from "@/components/canvas/PhotoControls/ExpandPhotoButtons.vue";

--- a/src/views/CanvasView.vue
+++ b/src/views/CanvasView.vue
@@ -470,6 +470,8 @@ const toolbarState = ref({
     opposite: false,
     autoAlign: false,
     onCanvas: false,
+    layout: "vertical", // vertical, horizontal, circular
+    photoCount: 3, // 1-5
   },
   photoOptions: {
     count: 1,

--- a/src/views/CanvasView.vue
+++ b/src/views/CanvasView.vue
@@ -253,18 +253,70 @@
           </template>
         </n-button>
 
-        <n-button @click="openConfig">
-          <template #icon>
-            <n-icon>
-              <svg viewBox="0 0 24 24">
-                <path
-                  fill="currentColor"
-                  d="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.22,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.22,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.68 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"
+        <div class="config-menu-container" ref="configMenuRef">
+          <n-button @click="openConfig">
+            <template #icon>
+              <n-icon>
+                <svg viewBox="0 0 24 24">
+                  <path
+                    fill="currentColor"
+                    d="M12,15.5A3.5,3.5 0 0,1 8.5,12A3.5,3.5 0 0,1 12,8.5A3.5,3.5 0 0,1 15.5,12A3.5,3.5 0 0,1 12,15.5M19.43,12.97C19.47,12.65 19.5,12.33 19.5,12C19.5,11.67 19.47,11.34 19.43,11L21.54,9.37C21.73,9.22 21.78,8.95 21.66,8.73L19.66,5.27C19.54,5.05 19.27,4.96 19.05,5.05L16.56,6.05C16.04,5.66 15.5,5.32 14.87,5.07L14.5,2.42C14.46,2.18 14.25,2 14,2H10C9.75,2 9.54,2.18 9.5,2.42L9.13,5.07C8.5,5.32 7.96,5.66 7.44,6.05L4.95,5.05C4.73,4.96 4.46,5.05 4.34,5.27L2.34,8.73C2.22,8.95 2.27,9.22 2.46,9.37L4.57,11C4.53,11.34 4.5,11.67 4.5,12C4.5,12.33 4.53,12.65 4.57,12.97L2.46,14.63C2.27,14.78 2.22,15.05 2.34,15.27L4.34,18.73C4.46,18.95 4.73,19.03 4.95,18.95L7.44,17.94C7.96,18.34 8.5,18.68 9.13,18.93L9.5,21.58C9.54,21.82 9.75,22 10,22H14C14.25,22 14.46,21.82 14.5,21.58L14.87,18.93C15.5,18.68 16.04,18.34 16.56,17.94L19.05,18.95C19.27,19.03 19.54,18.95 19.66,18.73L21.66,15.27C21.78,15.05 21.73,14.78 21.54,14.63L19.43,12.97Z"
+                  />
+                </svg>
+              </n-icon>
+            </template>
+          </n-button>
+
+          <!-- Config Menu Dropdown -->
+          <div v-if="showConfigMenu" class="config-dropdown" @click.stop>
+            <!-- Canvas Section -->
+            <div class="config-section">
+              <h4 class="section-title">Canvas</h4>
+              <div class="config-item">
+                <span class="config-label">Auto Align</span>
+                <n-switch v-model:value="toolbarState.expansion.autoAlign" />
+              </div>
+            </div>
+
+            <!-- Expansion Section -->
+            <div class="config-section">
+              <h4 class="section-title">Expansion</h4>
+
+              <!-- Layout Pills -->
+              <div class="config-item">
+                <span class="config-label">Layout</span>
+                <div class="layout-pills">
+                  <n-button
+                    v-for="layout in ['vertical', 'horizontal', 'circular']"
+                    :key="layout"
+                    :type="
+                      toolbarState.expansion.layout === layout
+                        ? 'primary'
+                        : 'default'
+                    "
+                    size="small"
+                    class="layout-pill"
+                    @click="toolbarState.expansion.layout = layout"
+                  >
+                    {{ layout.charAt(0).toUpperCase() + layout.slice(1) }}
+                  </n-button>
+                </div>
+              </div>
+
+              <!-- Photo Count -->
+              <div class="config-item">
+                <span class="config-label">Photos</span>
+                <n-input-number
+                  v-model:value="toolbarState.expansion.photoCount"
+                  :min="1"
+                  :max="5"
+                  size="small"
+                  style="width: 80px"
                 />
-              </svg>
-            </n-icon>
-          </template>
-        </n-button>
+              </div>
+            </div>
+          </div>
+        </div>
       </n-space>
     </div>
 


### PR DESCRIPTION
This pull request adds several UI improvements to the photo canvas components:

**PhotoBase.vue changes:**
- Added NCheckbox import from naive-ui
- Added "Opposite" checkbox control in the base image header
- Updated header layout with flexbox styling for better alignment
- Added CSS classes for expansion-type-select and opposite-checkbox
- Fixed trailing commas in function calls and watch options

**RelatedPhotosToolbar.vue changes:**
- Added NSkeleton import from naive-ui
- Added loading state prop and skeleton placeholders during photo loading
- Implemented handleLoadingState function to emit loading events
- Updated scrollbar styling with improved visibility
- Added responsive skeleton sizing for mobile breakpoints

**CanvasView.vue changes:**
- Added isLoadingRelatedPhotos state management
- Added comprehensive config menu dropdown with canvas and expansion settings
- Added NSwitch and NInputNumber imports for new config controls
- Implemented layout selection (vertical/horizontal/circular) and photo count controls
- Added config menu positioning and click-outside handling
- Enhanced toolbar state with new layout and photoCount properties
- Updated various function calls with proper trailing comma formatting

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 19`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e7707f36ee004767b325d7c562f1c2bb/swoosh-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e7707f36ee004767b325d7c562f1c2bb</projectId>-->
<!--<branchName>swoosh-haven</branchName>-->