### PR TITLE
Add collapsible search toolbar on scroll

### DIFF
--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -760,6 +760,9 @@ onMounted(() => {
 onUnmounted(() => {
   socket.off("matches");
   socket.off("maxPageAttempts");
+  if (scrollTimeout.value) {
+    clearTimeout(scrollTimeout.value);
+  }
 });
 
 // Carousel de ejemplos

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -583,36 +583,28 @@ function setGridColumns(n) {
 
 // Scroll-based collapse functionality
 const isCollapsed = ref(false);
-const lastScrollY = ref(0);
-const scrollTimeout = ref(null);
 
 function handleScroll(event) {
-  const currentScrollY = event.target.scrollTop;
+  const element = event.target;
+  const scrollTop = element.scrollTop;
+  const scrollHeight = element.scrollHeight;
+  const clientHeight = element.clientHeight;
 
-  // Clear any pending timeout
-  if (scrollTimeout.value) {
-    clearTimeout(scrollTimeout.value);
+  // Calculate scroll percentage
+  const maxScroll = scrollHeight - clientHeight;
+  if (maxScroll <= 0) return; // No scrollable content
+
+  const scrollPercentage = (scrollTop / maxScroll) * 100;
+
+  // Use hysteresis: different thresholds for collapsing vs expanding
+  // This prevents flickering by creating a "dead zone"
+  if (!isCollapsed.value && scrollPercentage > 15) {
+    // Collapse when scrolling down past 15%
+    isCollapsed.value = true;
+  } else if (isCollapsed.value && scrollPercentage < 5) {
+    // Expand when scrolling back up above 5%
+    isCollapsed.value = false;
   }
-
-  // Only trigger changes if we have meaningful scroll movement
-  const scrollDelta = Math.abs(currentScrollY - lastScrollY.value);
-  if (scrollDelta < 5) return; // Ignore very small movements
-
-  // Throttle the scroll updates to prevent flickering
-  scrollTimeout.value = setTimeout(() => {
-    const scrollDirection = currentScrollY > lastScrollY.value ? "down" : "up";
-
-    // Collapse when scrolling down and we're past a small threshold
-    if (scrollDirection === "down" && currentScrollY > 30) {
-      isCollapsed.value = true;
-    }
-    // Expand when scrolling up
-    else if (scrollDirection === "up") {
-      isCollapsed.value = false;
-    }
-
-    lastScrollY.value = currentScrollY;
-  }, 50); // 50ms throttle
 }
 
 // Obtiene texto de la consulta actual

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1244,6 +1244,46 @@ onUnmounted(() => {
   margin: 0;
 }
 
+/* Collapsed Grid Controls */
+.collapsed-grid-controls {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 12px 0;
+  border-bottom: 1px solid #2c2c32;
+  margin-bottom: 16px;
+  animation: slideDown 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.collapsed-results-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.collapsed-results-count {
+  font-size: 14px;
+  font-weight: 500;
+  color: #ffffffd1;
+}
+
+.collapsed-grid-size-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 /* Search Results */
 .search-results {
   flex: 1;

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -661,6 +661,7 @@ async function performSearch() {
   Object.keys(iterationsRecord).forEach((k) => delete iterationsRecord[k]);
   maxPageAttempts.value = false;
   isSearching.value = true;
+  isCollapsed.value = false; // Reset collapsed state
   await searchPhotos();
   isSearching.value = false;
 }

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1163,46 +1163,6 @@ onUnmounted(() => {
   margin: 0;
 }
 
-/* Collapsed Grid Controls */
-.collapsed-grid-controls {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 12px 0;
-  border-bottom: 1px solid #2c2c32;
-  margin-bottom: 16px;
-  animation: slideDown 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.collapsed-results-info {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.collapsed-results-count {
-  font-size: 14px;
-  font-weight: 500;
-  color: #ffffffd1;
-}
-
-.collapsed-grid-size-controls {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-@keyframes slideDown {
-  from {
-    opacity: 0;
-    transform: translateY(-10px);
-  }
-  to {
-    opacity: 1;
-    transform: translateY(0);
-  }
-}
-
 /* Search Results */
 .search-results {
   flex: 1;

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -752,9 +752,6 @@ onMounted(() => {
 onUnmounted(() => {
   socket.off("matches");
   socket.off("maxPageAttempts");
-  if (scrollTimeout.value) {
-    clearTimeout(scrollTimeout.value);
-  }
 });
 
 // Carousel de ejemplos

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1274,6 +1274,11 @@ onUnmounted(() => {
     margin-bottom: 24px;
   }
 
+  .search-toolbar.is-collapsed {
+    padding: 12px 16px;
+    margin-bottom: 12px;
+  }
+
   .search-selector-section {
     flex-direction: column;
     gap: 16px;

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -800,6 +800,17 @@ onUnmounted(() => {
   border-radius: 16px;
   padding: 24px;
   margin-bottom: 32px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  transition:
+    padding 0.3s ease,
+    margin-bottom 0.3s ease;
+}
+
+.search-toolbar.is-collapsed {
+  padding: 16px 24px;
+  margin-bottom: 16px;
 }
 
 /* Combined Search Selector Section */

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -838,6 +838,18 @@ onUnmounted(() => {
   padding-bottom: 20px;
   border-bottom: 1px solid #2c2c32;
   overflow: visible;
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  max-height: 200px;
+  opacity: 1;
+}
+
+.search-selector-section.collapsed {
+  max-height: 0;
+  opacity: 0;
+  margin-bottom: 0;
+  padding-bottom: 0;
+  border-bottom: none;
+  overflow: hidden;
 }
 
 .selector-group {

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -7,7 +7,7 @@
     <!-- Search Toolbar -->
     <div class="search-toolbar" :class="{ 'is-collapsed': isCollapsed }">
       <!-- Search Type and Mode Selector -->
-      <div class="search-selector-section">
+      <div v-show="!isCollapsed" class="search-selector-section">
         <!-- Search Type -->
         <div class="selector-group">
           <div class="selector-label">Search Type:</div>

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1,16 +1,9 @@
 <template>
-  <div
-    ref="scrollContainer"
-    class="search-container view-container"
-    @scroll="handleScroll"
-  >
+  <div ref="scrollContainer" class="search-container view-container">
     <!-- Search Toolbar -->
-    <div class="search-toolbar" :class="{ collapsed: isToolbarCollapsed }">
+    <div class="search-toolbar">
       <!-- Search Type and Mode Selector -->
-      <div
-        class="search-selector-section"
-        :class="{ collapsed: isToolbarCollapsed }"
-      >
+      <div class="search-selector-section">
         <!-- Search Type -->
         <div class="selector-group">
           <div class="selector-label">Search Type:</div>

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1,9 +1,16 @@
 <template>
-  <div ref="scrollContainer" class="search-container view-container">
+  <div
+    ref="scrollContainer"
+    class="search-container view-container"
+    @scroll="handleScroll"
+  >
     <!-- Search Toolbar -->
-    <div class="search-toolbar">
+    <div class="search-toolbar" :class="{ collapsed: isToolbarCollapsed }">
       <!-- Search Type and Mode Selector -->
-      <div class="search-selector-section">
+      <div
+        class="search-selector-section"
+        :class="{ collapsed: isToolbarCollapsed }"
+      >
         <!-- Search Type -->
         <div class="selector-group">
           <div class="selector-label">Search Type:</div>
@@ -570,7 +577,7 @@ const hasSearchQuery = computed(() => {
 // Columnas del grid y paginación
 const gridColumns = ref(3);
 const hasMoreResults = computed(
-  () => searchResults.value.length > 0 && !maxPageAttempts.value
+  () => searchResults.value.length > 0 && !maxPageAttempts.value,
 );
 
 function setGridColumns(n) {
@@ -582,7 +589,7 @@ function getCurrentQuery() {
   if (activeSearchType.value === "semantic") return semanticQuery.value;
   if (activeSearchType.value === "tags") {
     return `+${includedTags.value.join(", ")} -${excludedTags.value.join(
-      ", "
+      ", ",
     )}`;
   }
   return `${topological.left}|${topological.center}|${topological.right}`;
@@ -663,7 +670,7 @@ async function searchPhotos() {
       `${import.meta.env.VITE_API_BASE_URL}/api/search/${
         activeSearchType.value
       }`,
-      payload
+      payload,
     );
   } catch (err) {
     console.error("Error al buscar fotos:", err);
@@ -678,7 +685,7 @@ async function ensureWarmUp() {
   }, 5000);
 
   const { data } = await axios.get(
-    `${import.meta.env.VITE_API_BASE_URL}/api/search/warmUp`
+    `${import.meta.env.VITE_API_BASE_URL}/api/search/warmUp`,
   );
   warmedUp.value = data.result;
 
@@ -1000,7 +1007,7 @@ onUnmounted(() => {
   flex: 1;
   display: flex;
   flex-direction: column;
-  /* height: 80vh; 
+  /* height: 80vh;
   overflow-y: auto; */
 }
 

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -758,15 +758,6 @@ onUnmounted(() => {
   border-radius: 16px;
   padding: 24px;
   margin-bottom: 32px;
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  position: sticky;
-  top: 0;
-  z-index: 10;
-}
-
-.search-toolbar.collapsed {
-  padding: 16px 24px;
-  margin-bottom: 16px;
 }
 
 /* Combined Search Selector Section */

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -379,6 +379,28 @@
           </div>
         </div>
 
+        <!-- Collapsed Grid Controls (shown when toolbar is collapsed) -->
+        <div v-if="isToolbarCollapsed" class="collapsed-grid-controls">
+          <div class="collapsed-results-info">
+            <span class="collapsed-results-count"
+              >{{ searchResults.length }} photos</span
+            >
+          </div>
+          <div class="collapsed-grid-size-controls">
+            <n-button-group size="small">
+              <n-button
+                v-for="size in [3, 4, 5, 6]"
+                :key="size"
+                :type="gridColumns === size ? 'primary' : 'default'"
+                size="small"
+                @click="setGridColumns(size)"
+              >
+                {{ size }}
+              </n-button>
+            </n-button-group>
+          </div>
+        </div>
+
         <!-- Photo Grid -->
         <div
           class="photo-grid photo-grid-base"

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -577,36 +577,6 @@ function setGridColumns(n) {
   gridColumns.value = n;
 }
 
-// Scroll detection for toolbar collapse
-const isToolbarCollapsed = ref(false);
-const lastScrollTop = ref(0);
-const scrollThreshold = 50; // Minimum scroll distance to trigger collapse
-
-function handleScroll(event) {
-  const currentScrollTop = event.target.scrollTop;
-  const scrollDirection =
-    currentScrollTop > lastScrollTop.value ? "down" : "up";
-
-  // Only collapse if we've scrolled down past threshold and have search results
-  if (
-    scrollDirection === "down" &&
-    currentScrollTop > scrollThreshold &&
-    searchResults.value.length > 0
-  ) {
-    isToolbarCollapsed.value = true;
-  }
-  // Expand if scrolling up significantly or near top
-  else if (
-    scrollDirection === "up" &&
-    (currentScrollTop < scrollThreshold ||
-      Math.abs(currentScrollTop - lastScrollTop.value) > 20)
-  ) {
-    isToolbarCollapsed.value = false;
-  }
-
-  lastScrollTop.value = currentScrollTop;
-}
-
 // Obtiene texto de la consulta actual
 function getCurrentQuery() {
   if (activeSearchType.value === "semantic") return semanticQuery.value;

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -623,7 +623,6 @@ async function performSearch() {
   Object.keys(iterationsRecord).forEach((k) => delete iterationsRecord[k]);
   maxPageAttempts.value = false;
   isSearching.value = true;
-  isToolbarCollapsed.value = false; // Reset collapsed state when searching
   await searchPhotos();
   isSearching.value = false;
 }

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1388,6 +1388,23 @@ onUnmounted(() => {
     margin-bottom: 16px;
   }
 
+  .search-toolbar.collapsed {
+    padding: 8px 12px;
+    margin-bottom: 8px;
+  }
+
+  .collapsed-grid-controls {
+    padding: 6px 0;
+    margin-bottom: 8px;
+    flex-direction: column;
+    gap: 8px;
+    align-items: flex-start;
+  }
+
+  .collapsed-results-count {
+    font-size: 12px;
+  }
+
   .type-pills {
     gap: 2px;
   }

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -682,6 +682,7 @@ async function performSearch() {
   Object.keys(iterationsRecord).forEach((k) => delete iterationsRecord[k]);
   maxPageAttempts.value = false;
   isSearching.value = true;
+  isToolbarCollapsed.value = false; // Reset collapsed state when searching
   await searchPhotos();
   isSearching.value = false;
 }

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1,7 +1,11 @@
 <template>
-  <div ref="scrollContainer" class="search-container view-container">
+  <div
+    ref="scrollContainer"
+    class="search-container view-container"
+    @scroll="handleScroll"
+  >
     <!-- Search Toolbar -->
-    <div class="search-toolbar">
+    <div class="search-toolbar" :class="{ 'is-collapsed': isCollapsed }">
       <!-- Search Type and Mode Selector -->
       <div class="search-selector-section">
         <!-- Search Type -->

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -822,6 +822,9 @@ onUnmounted(() => {
   padding-bottom: 20px;
   border-bottom: 1px solid #2c2c32;
   overflow: visible;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
 }
 
 .selector-group {

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1253,23 +1253,6 @@ onUnmounted(() => {
     margin-bottom: 16px;
   }
 
-  .search-toolbar.collapsed {
-    padding: 8px 12px;
-    margin-bottom: 8px;
-  }
-
-  .collapsed-grid-controls {
-    padding: 6px 0;
-    margin-bottom: 8px;
-    flex-direction: column;
-    gap: 8px;
-    align-items: flex-start;
-  }
-
-  .collapsed-results-count {
-    font-size: 12px;
-  }
-
   .type-pills {
     gap: 2px;
   }

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -606,6 +606,36 @@ function setGridColumns(n) {
   gridColumns.value = n;
 }
 
+// Scroll detection for toolbar collapse
+const isToolbarCollapsed = ref(false);
+const lastScrollTop = ref(0);
+const scrollThreshold = 50; // Minimum scroll distance to trigger collapse
+
+function handleScroll(event) {
+  const currentScrollTop = event.target.scrollTop;
+  const scrollDirection =
+    currentScrollTop > lastScrollTop.value ? "down" : "up";
+
+  // Only collapse if we've scrolled down past threshold and have search results
+  if (
+    scrollDirection === "down" &&
+    currentScrollTop > scrollThreshold &&
+    searchResults.value.length > 0
+  ) {
+    isToolbarCollapsed.value = true;
+  }
+  // Expand if scrolling up significantly or near top
+  else if (
+    scrollDirection === "up" &&
+    (currentScrollTop < scrollThreshold ||
+      Math.abs(currentScrollTop - lastScrollTop.value) > 20)
+  ) {
+    isToolbarCollapsed.value = false;
+  }
+
+  lastScrollTop.value = currentScrollTop;
+}
+
 // Obtiene texto de la consulta actual
 function getCurrentQuery() {
   if (activeSearchType.value === "semantic") return semanticQuery.value;

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -581,6 +581,40 @@ function setGridColumns(n) {
   gridColumns.value = n;
 }
 
+// Scroll-based collapse functionality
+const isCollapsed = ref(false);
+const lastScrollY = ref(0);
+const scrollTimeout = ref(null);
+
+function handleScroll(event) {
+  const currentScrollY = event.target.scrollTop;
+
+  // Clear any pending timeout
+  if (scrollTimeout.value) {
+    clearTimeout(scrollTimeout.value);
+  }
+
+  // Only trigger changes if we have meaningful scroll movement
+  const scrollDelta = Math.abs(currentScrollY - lastScrollY.value);
+  if (scrollDelta < 5) return; // Ignore very small movements
+
+  // Throttle the scroll updates to prevent flickering
+  scrollTimeout.value = setTimeout(() => {
+    const scrollDirection = currentScrollY > lastScrollY.value ? "down" : "up";
+
+    // Collapse when scrolling down and we're past a small threshold
+    if (scrollDirection === "down" && currentScrollY > 30) {
+      isCollapsed.value = true;
+    }
+    // Expand when scrolling up
+    else if (scrollDirection === "up") {
+      isCollapsed.value = false;
+    }
+
+    lastScrollY.value = currentScrollY;
+  }, 50); // 50ms throttle
+}
+
 // Obtiene texto de la consulta actual
 function getCurrentQuery() {
   if (activeSearchType.value === "semantic") return semanticQuery.value;

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1339,9 +1339,23 @@ onUnmounted(() => {
     margin-bottom: 24px;
   }
 
+  .search-toolbar.collapsed {
+    padding: 12px 16px;
+    margin-bottom: 12px;
+  }
+
   .search-selector-section {
     flex-direction: column;
     gap: 16px;
+  }
+
+  .collapsed-grid-controls {
+    padding: 8px 0;
+    margin-bottom: 12px;
+  }
+
+  .collapsed-results-count {
+    font-size: 13px;
   }
 
   .selector-group:first-child,

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -818,6 +818,15 @@ onUnmounted(() => {
   border-radius: 16px;
   padding: 24px;
   margin-bottom: 32px;
+  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
+  position: sticky;
+  top: 0;
+  z-index: 10;
+}
+
+.search-toolbar.collapsed {
+  padding: 16px 24px;
+  margin-bottom: 16px;
 }
 
 /* Combined Search Selector Section */

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -372,28 +372,6 @@
           </div>
         </div>
 
-        <!-- Collapsed Grid Controls (shown when toolbar is collapsed) -->
-        <div v-if="isToolbarCollapsed" class="collapsed-grid-controls">
-          <div class="collapsed-results-info">
-            <span class="collapsed-results-count"
-              >{{ searchResults.length }} photos</span
-            >
-          </div>
-          <div class="collapsed-grid-size-controls">
-            <n-button-group size="small">
-              <n-button
-                v-for="size in [3, 4, 5, 6]"
-                :key="size"
-                :type="gridColumns === size ? 'primary' : 'default'"
-                size="small"
-                @click="setGridColumns(size)"
-              >
-                {{ size }}
-              </n-button>
-            </n-button-group>
-          </div>
-        </div>
-
         <!-- Photo Grid -->
         <div
           class="photo-grid photo-grid-base"

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1314,6 +1314,11 @@ onUnmounted(() => {
     margin-bottom: 16px;
   }
 
+  .search-toolbar.is-collapsed {
+    padding: 8px 12px;
+    margin-bottom: 8px;
+  }
+
   .type-pills {
     gap: 2px;
   }

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -1218,23 +1218,9 @@ onUnmounted(() => {
     margin-bottom: 24px;
   }
 
-  .search-toolbar.collapsed {
-    padding: 12px 16px;
-    margin-bottom: 12px;
-  }
-
   .search-selector-section {
     flex-direction: column;
     gap: 16px;
-  }
-
-  .collapsed-grid-controls {
-    padding: 8px 0;
-    margin-bottom: 12px;
-  }
-
-  .collapsed-results-count {
-    font-size: 13px;
   }
 
   .selector-group:first-child,

--- a/src/views/SearchView.vue
+++ b/src/views/SearchView.vue
@@ -769,18 +769,6 @@ onUnmounted(() => {
   padding-bottom: 20px;
   border-bottom: 1px solid #2c2c32;
   overflow: visible;
-  transition: all 0.4s cubic-bezier(0.4, 0, 0.2, 1);
-  max-height: 200px;
-  opacity: 1;
-}
-
-.search-selector-section.collapsed {
-  max-height: 0;
-  opacity: 0;
-  margin-bottom: 0;
-  padding-bottom: 0;
-  border-bottom: none;
-  overflow: hidden;
 }
 
 .selector-group {


### PR DESCRIPTION
Implements scroll-based collapsing functionality for the search toolbar in SearchView.vue.

Changes made:
- Added scroll event handler to the main container
- Implemented `handleScroll` function with hysteresis logic (15% threshold to collapse, 5% to expand)
- Added `isCollapsed` reactive state to control toolbar visibility
- Applied conditional CSS class `is-collapsed` to search toolbar
- Made search toolbar sticky with position and z-index styling
- Added smooth transitions for padding and margin changes
- Conditionally hide search selector section when collapsed
- Reset collapsed state when performing new searches
- Updated responsive styles for collapsed state on mobile devices
- Fixed trailing commas in various function calls and object literals

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 21`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e7707f36ee004767b325d7c562f1c2bb/swoosh-forge)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e7707f36ee004767b325d7c562f1c2bb</projectId>-->
<!--<branchName>swoosh-forge</branchName>-->