### PR TITLE
Make logo clickable and add duplicate filter to uploads

### DIFF
--- a/src/components/DashboardSidebar.vue
+++ b/src/components/DashboardSidebar.vue
@@ -247,13 +247,8 @@ const emit = defineEmits(["close-mobile-menu"]);
 const activeKey = computed(() => route.name as string);
 const canUseApp = computed(() => photosStore.canUseApp);
 
-// First section: Dashboard, Photo Hub, Collections
+// First section: Photo Hub, Collections
 const firstSectionOptions = computed(() => [
-  {
-    label: "Dashboard",
-    key: "dashboard",
-    icon: () => h(NIcon, null, { default: () => h(DashboardIcon) }),
-  },
   {
     label: "Photo Hub",
     key: "photo-hub",
@@ -274,7 +269,7 @@ const firstSectionOptions = computed(() => [
                   "position: absolute; top: -2px; right: -2px; width: 8px; height: 8px; background: #22c55e; border-radius: 50%; box-shadow: 0 0 6px #22c55e; animation: pulse 2s infinite;",
               })
             : null,
-        ]
+        ],
       ),
   },
 ]);

--- a/src/components/DashboardSidebar.vue
+++ b/src/components/DashboardSidebar.vue
@@ -24,7 +24,7 @@
         </div>
       </div>
 
-      <!-- First Menu Section: Dashboard, Photo Hub, Collections -->
+      <!-- First Menu Section: Photo Hub, Collections -->
       <n-menu
         :collapsed="false"
         :collapsed-width="64"
@@ -136,7 +136,7 @@
         </div>
       </div>
 
-      <!-- First Menu Section: Dashboard, Photo Hub, Collections -->
+      <!-- First Menu Section: Photo Hub, Collections -->
       <n-menu
         :collapsed="collapsed"
         :collapsed-width="64"

--- a/src/components/DashboardSidebar.vue
+++ b/src/components/DashboardSidebar.vue
@@ -11,7 +11,7 @@
     <!-- Mobile sidebar -->
     <div v-if="props.mobileMenuOpen" class="mobile-sidebar">
       <div class="logo-container">
-        <div class="logo">
+        <div class="logo clickable-logo" @click="goToDashboard">
           <div class="logo-icon">
             <n-icon size="28" color="#2563eb">
               <CameraOutline />
@@ -123,7 +123,7 @@
       </div>
 
       <div class="logo-container">
-        <div class="logo">
+        <div class="logo clickable-logo" @click="goToDashboard">
           <div class="logo-icon">
             <n-icon size="28" color="#2563eb">
               <CameraOutline />
@@ -348,6 +348,14 @@ const handleMenuSelect = (key: string) => {
   }
 };
 
+const goToDashboard = () => {
+  router.push({ name: "dashboard" });
+  // On mobile, close menu after selection
+  if (isMobile.value) {
+    emit("close-mobile-menu");
+  }
+};
+
 const handleMouseEnter = () => {
   if (!isMobile.value && menuMode.value === "hover") {
     collapsed.value = false;
@@ -432,6 +440,17 @@ onUnmounted(() => {
   align-items: center;
   gap: 12px;
   transition: gap 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.clickable-logo {
+  cursor: pointer;
+  border-radius: 8px;
+  padding: 4px;
+  transition: background-color 0.2s ease;
+}
+
+.clickable-logo:hover {
+  background-color: rgba(37, 99, 235, 0.1);
 }
 
 .logo-icon {

--- a/src/components/photo-hub/PhotosUpload.vue
+++ b/src/components/photo-hub/PhotosUpload.vue
@@ -179,11 +179,15 @@
       <div class="grid-controls grid-controls-base">
         <div class="results-info results-info-base">
           <span class="results-count results-count-base">
-            {{ uploadedPhotos.length }}
+            {{ filteredPhotos.length }}
             photos
           </span>
         </div>
         <div class="header-controls">
+          <div class="filter-controls">
+            <span class="filter-label">Filter duplicates:</span>
+            <n-switch v-model:value="filterDuplicates" size="small" />
+          </div>
           <div class="grid-size-controls grid-size-controls-base">
             <span class="grid-label grid-label-base">Columns:</span>
             <n-button-group>
@@ -206,7 +210,7 @@
         :class="`grid-cols-${gridColumns}`"
       >
         <PhotoCardHub
-          v-for="photo in uploadedPhotos"
+          v-for="photo in filteredPhotos"
           :key="photo.id"
           :photo="photo"
           @select="togglePhotoSelection"
@@ -244,11 +248,19 @@ const photosStore = usePhotosStore();
 const isUploading = ref(false);
 const gridColumns = ref(8);
 const fileInput = ref(null);
+const filterDuplicates = ref(false);
 
 const uploadedCount = ref(0);
 const totalFiles = ref(0);
 
 const uploadedPhotos = computed(() => photosStore.uploadedPhotos);
+
+const filteredPhotos = computed(() => {
+  if (!filterDuplicates.value) {
+    return uploadedPhotos.value;
+  }
+  return uploadedPhotos.value.filter((photo) => photo.isDuplicate);
+});
 
 const picaInstance = pica();
 const limit = pLimit(10);
@@ -278,9 +290,9 @@ async function uploadLocalFiles(event) {
         limit(() =>
           processAndUploadFile(file).then((photo) => {
             if (photo) uploadedPhotos.push(photo);
-          })
-        )
-      )
+          }),
+        ),
+      ),
     );
 
     // Set photos to checking duplicates state
@@ -319,7 +331,7 @@ async function processAndUploadFile(file) {
         fileType: resizedBlob.type,
         originalName: file.name,
       }),
-    }
+    },
   );
 
   if (!res.ok) throw new Error("Error obteniendo URLs firmadas");
@@ -471,6 +483,18 @@ onMounted(() => {
   display: flex;
   align-items: center;
   gap: 16px;
+}
+
+.filter-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.filter-label {
+  font-size: 14px;
+  color: #ffffff73;
+  white-space: nowrap;
 }
 
 .header-buttons {

--- a/src/components/photo-hub/PhotosUpload.vue
+++ b/src/components/photo-hub/PhotosUpload.vue
@@ -186,7 +186,11 @@
         <div class="header-controls">
           <div class="filter-controls">
             <span class="filter-label">Filter duplicates:</span>
-            <n-switch v-model:value="filterDuplicates" size="small" />
+            <n-switch
+              v-model:value="filterDuplicates"
+              size="medium"
+              :rail-style="() => ({ backgroundColor: '#3f3f46' })"
+            />
           </div>
           <div class="grid-size-controls grid-size-controls-base">
             <span class="grid-label grid-label-base">Columns:</span>
@@ -488,13 +492,18 @@ onMounted(() => {
 .filter-controls {
   display: flex;
   align-items: center;
-  gap: 8px;
+  gap: 12px;
+  padding: 8px 12px;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 6px;
+  border: 1px solid #2c2c32;
 }
 
 .filter-label {
   font-size: 14px;
-  color: #ffffff73;
+  color: #ffffffd1;
   white-space: nowrap;
+  font-weight: 500;
 }
 
 .header-buttons {

--- a/src/components/photo-hub/PhotosUpload.vue
+++ b/src/components/photo-hub/PhotosUpload.vue
@@ -185,12 +185,9 @@
         </div>
         <div class="header-controls">
           <div class="filter-controls">
-            <span class="filter-label">Filter duplicates:</span>
-            <n-switch
-              v-model:value="filterDuplicates"
-              size="medium"
-              :rail-style="() => ({ backgroundColor: '#3f3f46' })"
-            />
+            <n-checkbox v-model:checked="filterDuplicates" size="large">
+              Filter duplicates
+            </n-checkbox>
           </div>
           <div class="grid-size-controls grid-size-controls-base">
             <span class="grid-label grid-label-base">Columns:</span>
@@ -492,18 +489,10 @@ onMounted(() => {
 .filter-controls {
   display: flex;
   align-items: center;
-  gap: 12px;
   padding: 8px 12px;
   background-color: rgba(255, 255, 255, 0.05);
   border-radius: 6px;
   border: 1px solid #2c2c32;
-}
-
-.filter-label {
-  font-size: 14px;
-  color: #ffffffd1;
-  white-space: nowrap;
-  font-weight: 500;
 }
 
 .header-buttons {


### PR DESCRIPTION
This pull request makes two main changes:

**Dashboard Sidebar Updates:**
- Made logo clickable with navigation to dashboard
- Added hover styling for clickable logo
- Removed "Dashboard" menu item from first section
- Updated section comments to reflect menu changes
- Added `goToDashboard()` function with mobile menu handling

**Photo Upload Enhancements:**
- Added duplicate filter checkbox control
- Updated photo count display to show filtered results
- Created `filteredPhotos` computed property for duplicate filtering
- Added styling for filter controls section
- Updated photo grid to use filtered photos

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 27`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e7707f36ee004767b325d7c562f1c2bb/zenith-world)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e7707f36ee004767b325d7c562f1c2bb</projectId>-->
<!--<branchName>zenith-world</branchName>-->