### PR TITLE
Add Styler component with Explorer and Ranking tabs

### DIFF
--- a/src/components/DashboardSidebar.vue
+++ b/src/components/DashboardSidebar.vue
@@ -221,6 +221,7 @@ import {
   SearchOutline as SearchIcon,
   BrushOutline as CanvasIcon,
   ImagesOutline as CurationIcon,
+  ColorPaletteOutline as StylerIcon,
   AppsOutline as GridIcon,
   SettingsOutline as SettingsIcon,
   HelpCircleOutline as HelpIcon,
@@ -269,7 +270,7 @@ const firstSectionOptions = computed(() => [
                   "position: absolute; top: -2px; right: -2px; width: 8px; height: 8px; background: #22c55e; border-radius: 50%; box-shadow: 0 0 6px #22c55e; animation: pulse 2s infinite;",
               })
             : null,
-        ]
+        ],
       ),
   },
 ]);

--- a/src/components/DashboardSidebar.vue
+++ b/src/components/DashboardSidebar.vue
@@ -321,6 +321,17 @@ const secondSectionOptions = computed(() => [
       : {},
     icon: () => h(NIcon, null, { default: () => h(CurationIcon) }),
   },
+  {
+    label: "Styler",
+    key: "styler",
+    disabled: !canUseApp.value,
+    props: !canUseApp.value
+      ? {
+          title: "Add photos to your catalog",
+        }
+      : {},
+    icon: () => h(NIcon, null, { default: () => h(StylerIcon) }),
+  },
 ]);
 
 // Third section: Settings, Help (always enabled)

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -179,7 +179,7 @@ defineExpose({
 .explorer-content {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
 }
 
 .explorer-header {

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -28,15 +28,6 @@
         </n-tag>
       </div>
 
-      <div class="explorer-info" v-if="selectedAspects.length > 0">
-        <span class="selected-count"
-          >{{ selectedAspects.length }} characteristic{{
-            selectedAspects.length > 1 ? "s" : ""
-          }}
-          selected</span
-        >
-      </div>
-
       <div class="explorer-actions">
         <n-button
           type="primary"

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -1,0 +1,422 @@
+<template>
+  <div class="explorer-tab">
+    <div class="explorer-content">
+      <div class="explorer-header">
+        <h3 class="explorer-title">Style Explorer</h3>
+        <p class="explorer-subtitle">
+          Select aesthetic characteristics to find photos with those specific
+          qualities
+        </p>
+      </div>
+
+      <div class="pills-grid">
+        <div
+          v-for="aspect in aestheticAspects"
+          :key="aspect.key"
+          class="pill-item"
+          :class="{ selected: selectedAspects.includes(aspect.key) }"
+          @click="toggleAspect(aspect.key)"
+        >
+          <div class="pill-header">
+            <span class="pill-label">{{ aspect.label }}</span>
+            <div
+              class="pill-indicator"
+              v-if="selectedAspects.includes(aspect.key)"
+            >
+              <n-icon size="14">
+                <svg viewBox="0 0 24 24">
+                  <path
+                    fill="currentColor"
+                    d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"
+                  />
+                </svg>
+              </n-icon>
+            </div>
+          </div>
+          <p class="pill-description">{{ aspect.description }}</p>
+        </div>
+      </div>
+
+      <div class="explorer-info" v-if="selectedAspects.length > 0">
+        <span class="selected-count"
+          >{{ selectedAspects.length }} characteristic{{
+            selectedAspects.length > 1 ? "s" : ""
+          }}
+          selected</span
+        >
+      </div>
+
+      <div class="explorer-actions">
+        <n-button
+          type="primary"
+          :disabled="selectedAspects.length === 0"
+          @click="handleSearch"
+          class="search-button"
+        >
+          <template #icon>
+            <n-icon>
+              <svg viewBox="0 0 24 24">
+                <path
+                  fill="currentColor"
+                  d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5A6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5S14 7.01 14 9.5S11.99 14 9.5 14z"
+                />
+              </svg>
+            </n-icon>
+          </template>
+          Explore Photos
+        </n-button>
+
+        <n-button
+          secondary
+          @click="handleClear"
+          :disabled="selectedAspects.length === 0"
+          class="clear-button"
+        >
+          <template #icon>
+            <n-icon>
+              <svg viewBox="0 0 24 24">
+                <path
+                  fill="currentColor"
+                  d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41z"
+                />
+              </svg>
+            </n-icon>
+          </template>
+          Clear Selection
+        </n-button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref } from "vue";
+
+const emit = defineEmits(["search", "clear"]);
+
+// Same aesthetic aspects as RankingTab for consistency
+const aestheticAspects = [
+  {
+    key: "reflections",
+    label: "Reflections",
+    description: "Mirror-like surfaces, water reflections, glass reflections",
+  },
+  {
+    key: "lighting",
+    label: "Lighting",
+    description: "Dramatic lighting, golden hour, natural vs artificial light",
+  },
+  {
+    key: "yuxtapositions",
+    label: "Juxtapositions",
+    description: "Contrasting elements, old vs new, nature vs urban",
+  },
+  {
+    key: "symmetry",
+    label: "Symmetry",
+    description: "Balanced compositions, geometric patterns, mirror symmetry",
+  },
+  {
+    key: "depth",
+    label: "Depth of Field",
+    description: "Bokeh effects, shallow focus, background blur",
+  },
+  {
+    key: "colors",
+    label: "Color Harmony",
+    description:
+      "Complementary colors, monochromatic schemes, vibrant palettes",
+  },
+  {
+    key: "textures",
+    label: "Textures",
+    description: "Surface details, material contrasts, tactile qualities",
+  },
+  {
+    key: "minimalism",
+    label: "Minimalism",
+    description: "Clean compositions, negative space, simple elements",
+  },
+  {
+    key: "motion",
+    label: "Motion",
+    description: "Movement blur, dynamic poses, action capture",
+  },
+  {
+    key: "atmosphere",
+    label: "Atmosphere",
+    description: "Mood, ambiance, emotional tone, weather effects",
+  },
+];
+
+// Selected aesthetic aspects
+const selectedAspects = ref([]);
+
+// Toggle aspect selection
+const toggleAspect = (aspectKey) => {
+  const index = selectedAspects.value.indexOf(aspectKey);
+  if (index > -1) {
+    selectedAspects.value.splice(index, 1);
+  } else {
+    selectedAspects.value.push(aspectKey);
+  }
+};
+
+const handleSearch = () => {
+  if (selectedAspects.value.length === 0) return;
+
+  const searchParams = {
+    type: "explorer",
+    aspects: selectedAspects.value,
+  };
+
+  emit("search", searchParams);
+};
+
+const handleClear = () => {
+  selectedAspects.value = [];
+  emit("clear");
+};
+
+// Provide methods to parent if needed
+defineExpose({
+  selectedAspects,
+  toggleAspect,
+  clearSelection: handleClear,
+});
+</script>
+
+<style scoped>
+.explorer-tab {
+  padding: 0;
+}
+
+.explorer-content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.explorer-header {
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+.explorer-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #ffffffd1;
+  margin: 0 0 8px 0;
+}
+
+.explorer-subtitle {
+  font-size: 14px;
+  color: #ffffff73;
+  margin: 0;
+  line-height: 1.4;
+}
+
+.pills-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 12px;
+  margin: 8px 0;
+}
+
+.pill-item {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 14px 16px;
+  background-color: rgba(255, 255, 255, 0.02);
+  border: 1px solid #2c2c32;
+  border-radius: 12px;
+  cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  position: relative;
+}
+
+.pill-item:hover {
+  border-color: #3c3c42;
+  background-color: rgba(255, 255, 255, 0.04);
+  transform: translateY(-1px);
+}
+
+.pill-item.selected {
+  border-color: #2563eb;
+  background-color: rgba(37, 99, 235, 0.1);
+  transform: translateY(-1px);
+  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.2);
+}
+
+.pill-item.selected:hover {
+  border-color: #1d4ed8;
+  background-color: rgba(37, 99, 235, 0.15);
+}
+
+.pill-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 2px;
+}
+
+.pill-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #ffffffd1;
+  transition: color 0.2s ease;
+}
+
+.pill-item.selected .pill-label {
+  color: #ffffff;
+}
+
+.pill-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  background-color: #2563eb;
+  border-radius: 50%;
+  color: #ffffff;
+  opacity: 1;
+  transform: scale(1);
+  transition: all 0.2s ease;
+}
+
+.pill-description {
+  font-size: 12px;
+  color: #ffffff73;
+  margin: 0;
+  line-height: 1.3;
+  transition: color 0.2s ease;
+}
+
+.pill-item.selected .pill-description {
+  color: #ffffffa3;
+}
+
+.explorer-info {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 8px 16px;
+  background-color: rgba(37, 99, 235, 0.1);
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  border-radius: 20px;
+  max-width: 300px;
+  margin: 0 auto;
+}
+
+.selected-count {
+  font-size: 13px;
+  color: #2563eb;
+  font-weight: 500;
+}
+
+.explorer-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  align-items: center;
+  margin-top: 4px;
+}
+
+.search-button {
+  min-width: 140px;
+  height: 40px;
+  font-weight: 500;
+}
+
+.clear-button {
+  min-width: 120px;
+  height: 40px;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .pills-grid {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 10px;
+  }
+
+  .pill-item {
+    padding: 12px 14px;
+  }
+
+  .explorer-actions {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .search-button,
+  .clear-button {
+    width: 100%;
+    max-width: 300px;
+  }
+}
+
+@media (max-width: 480px) {
+  .explorer-header {
+    margin-bottom: 12px;
+  }
+
+  .explorer-title {
+    font-size: 16px;
+  }
+
+  .explorer-subtitle {
+    font-size: 13px;
+  }
+
+  .pills-grid {
+    grid-template-columns: 1fr;
+    gap: 8px;
+  }
+
+  .pill-item {
+    padding: 10px 12px;
+  }
+
+  .pill-label {
+    font-size: 13px;
+  }
+
+  .pill-description {
+    font-size: 11px;
+  }
+
+  .pill-indicator {
+    width: 18px;
+    height: 18px;
+  }
+
+  .explorer-info {
+    max-width: 250px;
+    padding: 6px 12px;
+  }
+
+  .selected-count {
+    font-size: 12px;
+  }
+}
+
+/* Animation for pill selection */
+@keyframes pillSelect {
+  0% {
+    transform: translateY(-1px) scale(1);
+  }
+  50% {
+    transform: translateY(-2px) scale(1.02);
+  }
+  100% {
+    transform: translateY(-1px) scale(1);
+  }
+}
+
+.pill-item.selected {
+  animation: pillSelect 0.3s ease;
+}
+</style>

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -203,86 +203,20 @@ defineExpose({
   line-height: 1.4;
 }
 
-.pills-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
-  gap: 12px;
-  margin: 8px 0;
-}
-
-.pill-item {
+.pills-container {
   display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 14px 16px;
-  background-color: rgba(255, 255, 255, 0.02);
-  border: 1px solid #2c2c32;
-  border-radius: 12px;
-  cursor: pointer;
-  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-  position: relative;
-}
-
-.pill-item:hover {
-  border-color: #3c3c42;
-  background-color: rgba(255, 255, 255, 0.04);
-  transform: translateY(-1px);
-}
-
-.pill-item.selected {
-  border-color: #2563eb;
-  background-color: rgba(37, 99, 235, 0.1);
-  transform: translateY(-1px);
-  box-shadow: 0 4px 12px rgba(37, 99, 235, 0.2);
-}
-
-.pill-item.selected:hover {
-  border-color: #1d4ed8;
-  background-color: rgba(37, 99, 235, 0.15);
-}
-
-.pill-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 2px;
-}
-
-.pill-label {
-  font-size: 14px;
-  font-weight: 500;
-  color: #ffffffd1;
-  transition: color 0.2s ease;
-}
-
-.pill-item.selected .pill-label {
-  color: #ffffff;
-}
-
-.pill-indicator {
-  display: flex;
-  align-items: center;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 12px 0;
   justify-content: center;
-  width: 20px;
-  height: 20px;
-  background-color: #2563eb;
-  border-radius: 50%;
-  color: #ffffff;
-  opacity: 1;
-  transform: scale(1);
+}
+
+.style-pill {
+  font-size: 13px;
+  font-weight: 500;
+  padding: 8px 14px;
+  cursor: pointer;
   transition: all 0.2s ease;
-}
-
-.pill-description {
-  font-size: 12px;
-  color: #ffffff73;
-  margin: 0;
-  line-height: 1.3;
-  transition: color 0.2s ease;
-}
-
-.pill-item.selected .pill-description {
-  color: #ffffffa3;
 }
 
 .explorer-info {

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -2,9 +2,15 @@
   <div class="explorer-tab">
     <div class="explorer-content">
       <div class="explorer-header">
-        <span class="header-text"
-          >Select aesthetic characteristics to explore</span
-        >
+        <div class="header-inline">
+          <span class="header-text"
+            >Select aesthetic characteristics to explore</span
+          >
+          <div v-if="selectedAspects.length > 0" class="selected-indicator">
+            <span class="selected-text">Selected:</span>
+            <span class="selected-count">{{ selectedAspects.length }}</span>
+          </div>
+        </div>
       </div>
 
       <div class="pills-container">

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -237,24 +237,6 @@ defineExpose({
   transition: all 0.2s ease;
 }
 
-.explorer-info {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  padding: 8px 16px;
-  background-color: rgba(37, 99, 235, 0.1);
-  border: 1px solid rgba(37, 99, 235, 0.2);
-  border-radius: 20px;
-  max-width: 300px;
-  margin: 0 auto;
-}
-
-.selected-count {
-  font-size: 13px;
-  color: #2563eb;
-  font-weight: 500;
-}
-
 .explorer-actions {
   display: flex;
   gap: 12px;

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -183,10 +183,42 @@ defineExpose({
   margin-bottom: 12px;
 }
 
+.header-inline {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+}
+
 .header-text {
   font-size: 14px;
   color: var(--text-secondary);
   font-weight: 500;
+}
+
+.selected-indicator {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.selected-text {
+  font-size: 12px;
+  color: var(--text-secondary);
+  font-weight: 500;
+}
+
+.selected-count {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--primary-color);
+  min-width: 20px;
+  text-align: center;
 }
 
 .pills-container {

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -207,7 +207,7 @@ defineExpose({
   display: flex;
   flex-wrap: wrap;
   gap: 8px;
-  margin: 12px 0;
+  margin: 8px 0;
   justify-content: center;
 }
 

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -183,22 +183,13 @@ defineExpose({
 }
 
 .explorer-header {
-  text-align: center;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
 }
 
-.explorer-title {
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin: 0 0 8px 0;
-}
-
-.explorer-subtitle {
+.header-text {
   font-size: 14px;
   color: var(--text-secondary);
-  margin: 0;
-  line-height: 1.4;
+  font-weight: 500;
 }
 
 .pills-container {

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -9,32 +9,19 @@
         </p>
       </div>
 
-      <div class="pills-grid">
-        <div
+      <div class="pills-container">
+        <n-tag
           v-for="aspect in aestheticAspects"
           :key="aspect.key"
-          class="pill-item"
-          :class="{ selected: selectedAspects.includes(aspect.key) }"
-          @click="toggleAspect(aspect.key)"
+          :type="selectedAspects.includes(aspect.key) ? 'primary' : 'default'"
+          :bordered="false"
+          checkable
+          :checked="selectedAspects.includes(aspect.key)"
+          @update:checked="() => toggleAspect(aspect.key)"
+          class="style-pill"
         >
-          <div class="pill-header">
-            <span class="pill-label">{{ aspect.label }}</span>
-            <div
-              class="pill-indicator"
-              v-if="selectedAspects.includes(aspect.key)"
-            >
-              <n-icon size="14">
-                <svg viewBox="0 0 24 24">
-                  <path
-                    fill="currentColor"
-                    d="M9 16.17L4.83 12l-1.42 1.41L9 19 21 7l-1.41-1.41L9 16.17z"
-                  />
-                </svg>
-              </n-icon>
-            </div>
-          </div>
-          <p class="pill-description">{{ aspect.description }}</p>
-        </div>
+          {{ aspect.label }}
+        </n-tag>
       </div>
 
       <div class="explorer-info" v-if="selectedAspects.length > 0">

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -2,11 +2,9 @@
   <div class="explorer-tab">
     <div class="explorer-content">
       <div class="explorer-header">
-        <h3 class="explorer-title">Style Explorer</h3>
-        <p class="explorer-subtitle">
-          Select aesthetic characteristics to find photos with those specific
-          qualities
-        </p>
+        <span class="header-text"
+          >Select aesthetic characteristics to explore</span
+        >
       </div>
 
       <div class="pills-container">

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -195,15 +195,15 @@ defineExpose({
 .pills-container {
   display: flex;
   flex-wrap: wrap;
-  gap: 8px;
-  margin: 8px 0;
+  gap: 6px;
+  margin: 6px 0;
   justify-content: center;
 }
 
 .style-pill {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
-  padding: 8px 14px;
+  padding: 6px 12px;
   cursor: pointer;
   transition: all 0.2s ease;
 }

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -258,15 +258,6 @@ defineExpose({
 
 /* Responsive Design */
 @media (max-width: 768px) {
-  .pills-grid {
-    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-    gap: 10px;
-  }
-
-  .pill-item {
-    padding: 12px 14px;
-  }
-
   .explorer-actions {
     flex-direction: column;
     gap: 8px;
@@ -292,26 +283,13 @@ defineExpose({
     font-size: 13px;
   }
 
-  .pills-grid {
-    grid-template-columns: 1fr;
-    gap: 8px;
+  .pills-container {
+    gap: 6px;
   }
 
-  .pill-item {
-    padding: 10px 12px;
-  }
-
-  .pill-label {
-    font-size: 13px;
-  }
-
-  .pill-description {
-    font-size: 11px;
-  }
-
-  .pill-indicator {
-    width: 18px;
-    height: 18px;
+  .style-pill {
+    font-size: 12px;
+    padding: 6px 10px;
   }
 
   .explorer-info {
@@ -322,22 +300,5 @@ defineExpose({
   .selected-count {
     font-size: 12px;
   }
-}
-
-/* Animation for pill selection */
-@keyframes pillSelect {
-  0% {
-    transform: translateY(-1px) scale(1);
-  }
-  50% {
-    transform: translateY(-2px) scale(1.02);
-  }
-  100% {
-    transform: translateY(-1px) scale(1);
-  }
-}
-
-.pill-item.selected {
-  animation: pillSelect 0.3s ease;
 }
 </style>

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -205,13 +205,13 @@ defineExpose({
 .explorer-title {
   font-size: 18px;
   font-weight: 600;
-  color: #ffffffd1;
+  color: var(--text-primary);
   margin: 0 0 8px 0;
 }
 
 .explorer-subtitle {
   font-size: 14px;
-  color: #ffffff73;
+  color: var(--text-secondary);
   margin: 0;
   line-height: 1.4;
 }

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -181,7 +181,7 @@ defineExpose({
 .explorer-content {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
 }
 
 .explorer-header {

--- a/src/components/styler/ExplorerTab.vue
+++ b/src/components/styler/ExplorerTab.vue
@@ -292,13 +292,13 @@ defineExpose({
     padding: 6px 10px;
   }
 
-  .explorer-info {
-    max-width: 250px;
-    padding: 6px 12px;
+  .selected-indicator {
+    padding: 3px 8px;
   }
 
+  .selected-text,
   .selected-count {
-    font-size: 12px;
+    font-size: 11px;
   }
 }
 </style>

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -303,19 +303,19 @@ defineExpose({
 }
 
 .sliders-container {
-  margin: 16px 0;
+  margin: 8px 0;
 }
 
 .sliders-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
 }
 
 .slider-item {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 6px;
 }
 
 .slider-header {

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -308,27 +308,20 @@ defineExpose({
   color: #10b981;
 }
 
+.sliders-container {
+  margin: 16px 0;
+}
+
 .sliders-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
-  gap: 20px;
-  margin: 16px 0;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 16px;
 }
 
 .slider-item {
   display: flex;
   flex-direction: column;
   gap: 8px;
-  padding: 16px;
-  background-color: rgba(255, 255, 255, 0.02);
-  border: 1px solid #2c2c32;
-  border-radius: 12px;
-  transition: all 0.2s ease;
-}
-
-.slider-item:hover {
-  border-color: #3c3c42;
-  background-color: rgba(255, 255, 255, 0.04);
 }
 
 .slider-header {

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -263,13 +263,13 @@ defineExpose({
 .ranking-title {
   font-size: 18px;
   font-weight: 600;
-  color: #ffffffd1;
+  color: var(--text-primary);
   margin: 0 0 8px 0;
 }
 
 .ranking-subtitle {
   font-size: 14px;
-  color: #ffffff73;
+  color: var(--text-secondary);
   margin: 0 0 16px 0;
   line-height: 1.4;
 }

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -371,12 +371,8 @@ defineExpose({
 /* Responsive Design */
 @media (max-width: 768px) {
   .sliders-grid {
-    grid-template-columns: 1fr;
-    gap: 16px;
-  }
-
-  .slider-item {
-    padding: 12px;
+    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    gap: 12px;
   }
 
   .ranking-actions {
@@ -417,19 +413,16 @@ defineExpose({
     font-size: 13px;
   }
 
-  .slider-item {
-    padding: 10px;
+  .sliders-grid {
+    grid-template-columns: 1fr;
+    gap: 10px;
   }
 
   .slider-label {
-    font-size: 13px;
-  }
-
-  .slider-value {
     font-size: 12px;
   }
 
-  .slider-description {
+  .slider-value {
     font-size: 11px;
   }
 }

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -253,35 +253,31 @@ defineExpose({
 }
 
 .ranking-header {
-  text-align: center;
-  margin-bottom: 8px;
+  margin-bottom: 12px;
 }
 
-.ranking-title {
-  font-size: 18px;
-  font-weight: 600;
-  color: var(--text-primary);
-  margin: 0 0 8px 0;
+.header-inline {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
 }
 
-.ranking-subtitle {
+.header-text {
   font-size: 14px;
   color: var(--text-secondary);
-  margin: 0 0 16px 0;
-  line-height: 1.4;
+  font-weight: 500;
 }
 
 .points-indicator {
   display: flex;
   align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 8px 16px;
+  gap: 6px;
+  padding: 4px 12px;
   background-color: rgba(255, 255, 255, 0.05);
-  border-radius: 20px;
-  border: 1px solid #2c2c32;
-  max-width: 200px;
-  margin: 0 auto;
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  flex-shrink: 0;
 }
 
 .points-text {

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -322,20 +322,20 @@ defineExpose({
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: 4px;
 }
 
 .slider-label {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 500;
   color: var(--text-primary);
 }
 
 .slider-value {
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 600;
   color: var(--primary-color);
-  min-width: 25px;
+  min-width: 20px;
   text-align: right;
 }
 

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -341,6 +341,29 @@ defineExpose({
 
 .aesthetic-slider {
   width: 100%;
+  height: 16px;
+  margin: 4px 0;
+}
+
+:deep(.n-slider) {
+  height: 16px;
+}
+
+:deep(.n-slider-rail) {
+  height: 4px;
+  background-color: var(--border-color);
+}
+
+:deep(.n-slider-fill) {
+  height: 4px;
+  background-color: var(--primary-color);
+}
+
+:deep(.n-slider-handle) {
+  width: 12px;
+  height: 12px;
+  border: 2px solid var(--primary-color);
+  background-color: #ffffff;
 }
 
 .ranking-actions {

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -249,7 +249,7 @@ defineExpose({
 .ranking-content {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
 }
 
 .ranking-header {

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -281,16 +281,16 @@ defineExpose({
 }
 
 .points-text {
-  font-size: 13px;
-  color: #ffffff73;
+  font-size: 12px;
+  color: var(--text-secondary);
   font-weight: 500;
 }
 
 .points-value {
-  font-size: 14px;
+  font-size: 12px;
   font-weight: 600;
-  color: #ffffffd1;
-  min-width: 30px;
+  color: var(--text-primary);
+  min-width: 20px;
   text-align: center;
 }
 

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -2,22 +2,20 @@
   <div class="ranking-tab">
     <div class="ranking-content">
       <div class="ranking-header">
-        <h3 class="ranking-title">Aesthetic Ranking Criteria</h3>
-        <p class="ranking-subtitle">
-          Distribute 100 points across aesthetic aspects to define your ranking
-          criteria
-        </p>
-        <div class="points-indicator">
-          <span class="points-text">Remaining Points:</span>
-          <span
-            class="points-value"
-            :class="{
-              warning: remainingPoints < 0,
-              success: remainingPoints === 0,
-            }"
-          >
-            {{ remainingPoints }}
-          </span>
+        <div class="header-inline">
+          <span class="header-text">Distribute 100 points across aspects</span>
+          <div class="points-indicator">
+            <span class="points-text">Remaining:</span>
+            <span
+              class="points-value"
+              :class="{
+                warning: remainingPoints < 0,
+                success: remainingPoints === 0,
+              }"
+            >
+              {{ remainingPoints }}
+            </span>
+          </div>
         </div>
       </div>
 

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -1,0 +1,455 @@
+<template>
+  <div class="ranking-tab">
+    <div class="ranking-content">
+      <div class="ranking-header">
+        <h3 class="ranking-title">Aesthetic Ranking Criteria</h3>
+        <p class="ranking-subtitle">
+          Distribute 100 points across aesthetic aspects to define your ranking
+          criteria
+        </p>
+        <div class="points-indicator">
+          <span class="points-text">Remaining Points:</span>
+          <span
+            class="points-value"
+            :class="{
+              warning: remainingPoints < 0,
+              success: remainingPoints === 0,
+            }"
+          >
+            {{ remainingPoints }}
+          </span>
+        </div>
+      </div>
+
+      <div class="sliders-grid">
+        <div
+          v-for="aspect in aestheticAspects"
+          :key="aspect.key"
+          class="slider-item"
+        >
+          <div class="slider-header">
+            <label class="slider-label">{{ aspect.label }}</label>
+            <span class="slider-value">{{ values[aspect.key] }}</span>
+          </div>
+          <div class="slider-container">
+            <n-slider
+              v-model:value="values[aspect.key]"
+              :min="0"
+              :max="100"
+              :step="1"
+              :tooltip="false"
+              @update:value="handleSliderChange"
+              class="aesthetic-slider"
+            />
+          </div>
+          <p class="slider-description">{{ aspect.description }}</p>
+        </div>
+      </div>
+
+      <div class="ranking-actions">
+        <n-button
+          type="primary"
+          :disabled="!isValidDistribution"
+          @click="handleSearch"
+          class="search-button"
+        >
+          <template #icon>
+            <n-icon>
+              <svg viewBox="0 0 24 24">
+                <path
+                  fill="currentColor"
+                  d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5A6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5S14 7.01 14 9.5S11.99 14 9.5 14z"
+                />
+              </svg>
+            </n-icon>
+          </template>
+          Search by Ranking
+        </n-button>
+
+        <n-button
+          secondary
+          @click="handleClear"
+          :disabled="totalPoints === 0"
+          class="clear-button"
+        >
+          <template #icon>
+            <n-icon>
+              <svg viewBox="0 0 24 24">
+                <path
+                  fill="currentColor"
+                  d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12L19 6.41z"
+                />
+              </svg>
+            </n-icon>
+          </template>
+          Clear All
+        </n-button>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, computed, reactive, watch } from "vue";
+
+const emit = defineEmits(["search", "clear"]);
+
+// Aesthetic aspects for ranking
+const aestheticAspects = [
+  {
+    key: "reflections",
+    label: "Reflections",
+    description: "Mirror-like surfaces, water reflections, glass reflections",
+  },
+  {
+    key: "lighting",
+    label: "Lighting",
+    description: "Dramatic lighting, golden hour, natural vs artificial light",
+  },
+  {
+    key: "yuxtapositions",
+    label: "Juxtapositions",
+    description: "Contrasting elements, old vs new, nature vs urban",
+  },
+  {
+    key: "symmetry",
+    label: "Symmetry",
+    description: "Balanced compositions, geometric patterns, mirror symmetry",
+  },
+  {
+    key: "depth",
+    label: "Depth of Field",
+    description: "Bokeh effects, shallow focus, background blur",
+  },
+  {
+    key: "colors",
+    label: "Color Harmony",
+    description:
+      "Complementary colors, monochromatic schemes, vibrant palettes",
+  },
+  {
+    key: "textures",
+    label: "Textures",
+    description: "Surface details, material contrasts, tactile qualities",
+  },
+  {
+    key: "minimalism",
+    label: "Minimalism",
+    description: "Clean compositions, negative space, simple elements",
+  },
+  {
+    key: "motion",
+    label: "Motion",
+    description: "Movement blur, dynamic poses, action capture",
+  },
+  {
+    key: "atmosphere",
+    label: "Atmosphere",
+    description: "Mood, ambiance, emotional tone, weather effects",
+  },
+];
+
+// Values for each aesthetic aspect (0-100 points)
+const values = reactive({});
+
+// Initialize all values to 0
+aestheticAspects.forEach((aspect) => {
+  values[aspect.key] = 0;
+});
+
+// Computed values
+const totalPoints = computed(() => {
+  return Object.values(values).reduce((sum, value) => sum + value, 0);
+});
+
+const remainingPoints = computed(() => {
+  return 100 - totalPoints.value;
+});
+
+const isValidDistribution = computed(() => {
+  return totalPoints.value === 100;
+});
+
+// Handle slider changes with zero-sum constraint
+const handleSliderChange = () => {
+  // If total exceeds 100, proportionally reduce other values
+  if (totalPoints.value > 100) {
+    const excess = totalPoints.value - 100;
+    redistributeExcess(excess);
+  }
+};
+
+const redistributeExcess = (excess) => {
+  // Find the slider that was just changed (has the highest value or most recent change)
+  // For simplicity, we'll just cap all values proportionally
+  const total = totalPoints.value;
+  if (total > 100) {
+    const factor = 100 / total;
+    Object.keys(values).forEach((key) => {
+      values[key] = Math.round(values[key] * factor);
+    });
+  }
+};
+
+const handleSearch = () => {
+  if (!isValidDistribution.value) return;
+
+  // Create search parameters with only non-zero values
+  const searchParams = {
+    type: "ranking",
+    criteria: Object.fromEntries(
+      Object.entries(values).filter(([_, value]) => value > 0),
+    ),
+  };
+
+  emit("search", searchParams);
+};
+
+const handleClear = () => {
+  Object.keys(values).forEach((key) => {
+    values[key] = 0;
+  });
+  emit("clear");
+};
+
+// Auto-distribute function for even distribution
+const autoDistribute = () => {
+  const nonZeroCount = Object.values(values).filter((v) => v > 0).length;
+  if (nonZeroCount === 0) {
+    // Distribute evenly among all
+    const evenValue = Math.floor(100 / aestheticAspects.length);
+    const remainder = 100 % aestheticAspects.length;
+
+    aestheticAspects.forEach((aspect, index) => {
+      values[aspect.key] = evenValue + (index < remainder ? 1 : 0);
+    });
+  } else {
+    // Distribute evenly among non-zero values
+    const evenValue = Math.floor(100 / nonZeroCount);
+    const remainder = 100 % nonZeroCount;
+
+    let distributedCount = 0;
+    Object.keys(values).forEach((key) => {
+      if (values[key] > 0) {
+        values[key] = evenValue + (distributedCount < remainder ? 1 : 0);
+        distributedCount++;
+      }
+    });
+  }
+};
+
+// Provide auto-distribute function to parent if needed
+defineExpose({
+  autoDistribute,
+});
+</script>
+
+<style scoped>
+.ranking-tab {
+  padding: 0;
+}
+
+.ranking-content {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.ranking-header {
+  text-align: center;
+  margin-bottom: 8px;
+}
+
+.ranking-title {
+  font-size: 18px;
+  font-weight: 600;
+  color: #ffffffd1;
+  margin: 0 0 8px 0;
+}
+
+.ranking-subtitle {
+  font-size: 14px;
+  color: #ffffff73;
+  margin: 0 0 16px 0;
+  line-height: 1.4;
+}
+
+.points-indicator {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 8px 16px;
+  background-color: rgba(255, 255, 255, 0.05);
+  border-radius: 20px;
+  border: 1px solid #2c2c32;
+  max-width: 200px;
+  margin: 0 auto;
+}
+
+.points-text {
+  font-size: 13px;
+  color: #ffffff73;
+  font-weight: 500;
+}
+
+.points-value {
+  font-size: 14px;
+  font-weight: 600;
+  color: #ffffffd1;
+  min-width: 30px;
+  text-align: center;
+}
+
+.points-value.warning {
+  color: #f59e0b;
+}
+
+.points-value.success {
+  color: #10b981;
+}
+
+.sliders-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 20px;
+  margin: 16px 0;
+}
+
+.slider-item {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 16px;
+  background-color: rgba(255, 255, 255, 0.02);
+  border: 1px solid #2c2c32;
+  border-radius: 12px;
+  transition: all 0.2s ease;
+}
+
+.slider-item:hover {
+  border-color: #3c3c42;
+  background-color: rgba(255, 255, 255, 0.04);
+}
+
+.slider-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 4px;
+}
+
+.slider-label {
+  font-size: 14px;
+  font-weight: 500;
+  color: #ffffffd1;
+}
+
+.slider-value {
+  font-size: 13px;
+  font-weight: 600;
+  color: #2563eb;
+  min-width: 30px;
+  text-align: right;
+}
+
+.slider-container {
+  margin: 8px 0;
+}
+
+.aesthetic-slider {
+  width: 100%;
+}
+
+.slider-description {
+  font-size: 12px;
+  color: #ffffff73;
+  margin: 0;
+  line-height: 1.3;
+}
+
+.ranking-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  align-items: center;
+  margin-top: 8px;
+}
+
+.search-button {
+  min-width: 160px;
+  height: 40px;
+  font-weight: 500;
+}
+
+.clear-button {
+  min-width: 120px;
+  height: 40px;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+  .sliders-grid {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+
+  .slider-item {
+    padding: 12px;
+  }
+
+  .ranking-actions {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .search-button,
+  .clear-button {
+    width: 100%;
+    max-width: 300px;
+  }
+}
+
+@media (max-width: 480px) {
+  .ranking-header {
+    margin-bottom: 16px;
+  }
+
+  .ranking-title {
+    font-size: 16px;
+  }
+
+  .ranking-subtitle {
+    font-size: 13px;
+  }
+
+  .points-indicator {
+    max-width: 180px;
+    padding: 6px 12px;
+  }
+
+  .points-text {
+    font-size: 12px;
+  }
+
+  .points-value {
+    font-size: 13px;
+  }
+
+  .slider-item {
+    padding: 10px;
+  }
+
+  .slider-label {
+    font-size: 13px;
+  }
+
+  .slider-value {
+    font-size: 12px;
+  }
+
+  .slider-description {
+    font-size: 11px;
+  }
+}
+</style>

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -251,7 +251,7 @@ defineExpose({
 .ranking-content {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 16px;
 }
 
 .ranking-header {

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -21,17 +21,17 @@
         </div>
       </div>
 
-      <div class="sliders-grid">
-        <div
-          v-for="aspect in aestheticAspects"
-          :key="aspect.key"
-          class="slider-item"
-        >
-          <div class="slider-header">
-            <label class="slider-label">{{ aspect.label }}</label>
-            <span class="slider-value">{{ values[aspect.key] }}</span>
-          </div>
-          <div class="slider-container">
+      <div class="sliders-container">
+        <div class="sliders-grid">
+          <div
+            v-for="aspect in aestheticAspects"
+            :key="aspect.key"
+            class="slider-item"
+          >
+            <div class="slider-header">
+              <label class="slider-label">{{ aspect.label }}</label>
+              <span class="slider-value">{{ values[aspect.key] }}</span>
+            </div>
             <n-slider
               v-model:value="values[aspect.key]"
               :min="0"
@@ -42,7 +42,6 @@
               class="aesthetic-slider"
             />
           </div>
-          <p class="slider-description">{{ aspect.description }}</p>
         </div>
       </div>
 

--- a/src/components/styler/RankingTab.vue
+++ b/src/components/styler/RankingTab.vue
@@ -328,36 +328,25 @@ defineExpose({
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 4px;
+  margin-bottom: 8px;
 }
 
 .slider-label {
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 500;
-  color: #ffffffd1;
+  color: var(--text-primary);
 }
 
 .slider-value {
-  font-size: 13px;
+  font-size: 12px;
   font-weight: 600;
-  color: #2563eb;
-  min-width: 30px;
+  color: var(--primary-color);
+  min-width: 25px;
   text-align: right;
-}
-
-.slider-container {
-  margin: 8px 0;
 }
 
 .aesthetic-slider {
   width: 100%;
-}
-
-.slider-description {
-  font-size: 12px;
-  color: #ffffff73;
-  margin: 0;
-  line-height: 1.3;
 }
 
 .ranking-actions {

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -95,6 +95,14 @@ const router = createRouter({
       },
     },
     {
+      path: "/styler",
+      name: "styler",
+      component: StylerView,
+      meta: {
+        requiresAuth: true,
+      },
+    },
+    {
       path: "/grid-maker",
       name: "grid-maker",
       component: GridMaker,

--- a/src/router/index.ts
+++ b/src/router/index.ts
@@ -13,6 +13,7 @@ import AuthView from "../views/AuthView.vue";
 import ProfileSelectionView from "../views/ProfileSelectionView.vue";
 import StoragePlanSelectionView from "../views/StoragePlanSelectionView.vue";
 import GridMaker from "@/views/GridMaker.vue";
+import StylerView from "@/views/StylerView.vue";
 
 const router = createRouter({
   history: createWebHistory(import.meta.env.BASE_URL),

--- a/src/views/StylerView.vue
+++ b/src/views/StylerView.vue
@@ -1,0 +1,690 @@
+<template>
+  <div ref="scrollContainer" class="styler-container view-container">
+    <!-- Styler Toolbar -->
+    <div class="styler-toolbar" :class="{ 'is-collapsed': isToolbarCollapsed }">
+      <!-- Tab Navigation -->
+      <div class="styler-tabs">
+        <div class="tab-navigation">
+          <button
+            class="tab-button"
+            :class="{ active: activeTab === 'ranking' }"
+            @click="setActiveTab('ranking')"
+          >
+            Ranking
+          </button>
+          <button
+            class="tab-button"
+            :class="{ active: activeTab === 'explorer' }"
+            @click="setActiveTab('explorer')"
+          >
+            Explorer
+          </button>
+        </div>
+
+        <!-- Tab Content -->
+        <div class="tab-content-container">
+          <!-- Ranking Tab -->
+          <RankingTab
+            v-show="activeTab === 'ranking'"
+            @search="performSearch"
+            @clear="clearSearch"
+          />
+
+          <!-- Explorer Tab -->
+          <ExplorerTab
+            v-show="activeTab === 'explorer'"
+            @search="performSearch"
+            @clear="clearSearch"
+          />
+        </div>
+      </div>
+    </div>
+
+    <!-- Search Results / Empty State -->
+    <div class="search-results-container">
+      <div v-if="!hasSearchQuery && !isSearching" class="search-inspiration">
+        <div class="inspiration-content">
+          <n-icon size="64" color="#6b7280" class="inspiration-icon">
+            <svg viewBox="0 0 24 24">
+              <path
+                fill="currentColor"
+                d="M9.5 3A6.5 6.5 0 0 1 16 9.5c0 1.61-.59 3.09-1.56 4.23l.27.27h.79l5 5l-1.5 1.5l-5-5v-.79l-.27-.27A6.516 6.516 0 0 1 9.5 16A6.5 6.5 0 0 1 3 9.5A6.5 6.5 0 0 1 9.5 3m0 2C7.01 5 5 7.01 5 9.5S7.01 14 9.5 14S14 11.99 14 9.5S11.99 5 9.5 5Z"
+              />
+            </svg>
+          </n-icon>
+          <h3 class="examples-title">Find your photos by style</h3>
+        </div>
+      </div>
+
+      <div v-else-if="isSearching" class="search-loading">
+        <div class="loading-message">
+          <n-spin size="large" />
+          <p class="loading-text">Searching through your photos...</p>
+        </div>
+
+        <!-- Skeleton Grid -->
+        <div
+          class="photo-grid photo-grid-base"
+          :class="`grid-cols-${gridColumns}`"
+        >
+          <div
+            v-for="n in skeletonCount"
+            :key="`styler-skeleton-${n}`"
+            class="photo-skeleton"
+          >
+            <n-skeleton height="100%" />
+          </div>
+        </div>
+      </div>
+
+      <div v-else class="search-results">
+        <!-- Grid Controls -->
+        <div class="grid-controls grid-controls-base">
+          <div class="results-info results-info-base">
+            <span class="results-count results-count-base"
+              >{{ searchResults.length }} photos found</span
+            >
+          </div>
+          <div class="grid-size-controls grid-size-controls-base">
+            <span class="grid-label grid-label-base">Columns:</span>
+            <n-button-group>
+              <n-button
+                v-for="size in [3, 4, 5, 6]"
+                :key="size"
+                :type="gridColumns === size ? 'primary' : 'default'"
+                size="small"
+                @click="setGridColumns(size)"
+              >
+                {{ size }}
+              </n-button>
+            </n-button-group>
+          </div>
+        </div>
+
+        <!-- Photo Grid -->
+        <div
+          class="photo-grid photo-grid-base"
+          :class="`grid-cols-${gridColumns}`"
+        >
+          <!-- Photo Cards -->
+          <PhotoCard
+            v-for="photo in searchResults"
+            :key="photo.id"
+            :photo="photo"
+            :selected="photoStore.selectedPhotoIds.includes(photo.id)"
+            @select="togglePhotoSelection"
+            @info="showPhotoInfo"
+          />
+
+          <!-- Skeleton Loading for Load More -->
+          <template v-if="isLoadingMore">
+            <div
+              v-for="n in pageSize"
+              :key="`skeleton-${n}`"
+              class="photo-skeleton"
+            >
+              <n-skeleton height="100%" />
+            </div>
+          </template>
+        </div>
+
+        <!-- Selection Info -->
+        <div
+          v-if="photoStore.selectedPhotoIds.length > 0 && selectInfoVisible"
+          class="selection-info"
+        >
+          <n-button type="info" @click="moveToCanvas">
+            Take to Canvas
+          </n-button>
+          <n-button type="info"> Create Collection </n-button>
+
+          <span
+            >{{ photoStore.selectedPhotoIds.length }} photo{{
+              photoStore.selectedPhotoIds.length > 1 ? "s" : ""
+            }}
+          </span>
+          <n-button type="secondary" @click="clearSelection">
+            <template #icon>
+              <n-icon>
+                <svg viewBox="0 0 24 24">
+                  <path
+                    fill="currentColor"
+                    d="M19 6.41L17.59 5L12 10.59L6.41 5L5 6.41L10.59 12L5 17.59L6.41 19L12 13.41L17.59 19L19 17.59L13.41 12z"
+                  />
+                </svg>
+              </n-icon>
+            </template>
+          </n-button>
+        </div>
+
+        <!-- Load More Button -->
+        <div class="load-more-container" v-if="hasMoreIterations">
+          <n-button
+            size="large"
+            :loading="isLoadingMore"
+            @click="loadMorePhotos"
+            class="load-more-button"
+          >
+            <template #icon>
+              <n-icon>
+                <svg viewBox="0 0 24 24">
+                  <path
+                    fill="currentColor"
+                    d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+                  />
+                </svg>
+              </n-icon>
+            </template>
+            Load More Photos
+          </n-button>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+defineOptions({ name: "StylerPage" });
+
+import { ref, reactive, computed, onMounted, onUnmounted, nextTick } from "vue";
+import axios from "axios";
+import { io } from "socket.io-client";
+
+import PhotoCard from "@/components/photoCards/PhotoCard.vue";
+import RankingTab from "@/components/styler/RankingTab.vue";
+import ExplorerTab from "@/components/styler/ExplorerTab.vue";
+
+import { usePhotosStore } from "@/stores/photos";
+import { useCanvasStore } from "@/stores/canvas.js";
+import { useRouter } from "vue-router";
+
+const socket = io(import.meta.env.VITE_API_WS_URL);
+
+const photoStore = usePhotosStore();
+const canvasStore = useCanvasStore();
+const router = useRouter();
+
+// State
+const activeTab = ref("ranking");
+const isToolbarCollapsed = ref(false);
+const selectInfoVisible = ref(true);
+const lastScrollY = ref(0);
+const scrollContainer = ref(null);
+
+// Search state
+const isSearching = ref(false);
+const isLoadingMore = ref(false);
+const hasMoreIterations = ref(false);
+const iteration = ref(1);
+let iterationsRecord = reactive({});
+const pageSize = ref(12);
+const gridColumns = ref(6);
+
+// Current search parameters
+const currentSearchParams = ref({});
+
+// Results
+const searchResults = computed(() => {
+  const keys = Object.keys(iterationsRecord)
+    .map(Number)
+    .sort((a, b) => a - b);
+  let all = [];
+  for (let i = 0; i < iteration.value; i++) {
+    const k = keys[i];
+    if (k !== undefined && iterationsRecord[k]?.photos) {
+      all.push(...iterationsRecord[k].photos);
+    }
+  }
+  return all;
+});
+
+const skeletonCount = computed(() => pageSize.value);
+
+const hasSearchQuery = computed(() => {
+  return Object.keys(currentSearchParams.value).length > 0;
+});
+
+// Functions
+const setActiveTab = (tab) => {
+  activeTab.value = tab;
+  clearSearch();
+};
+
+const setGridColumns = (n) => {
+  gridColumns.value = n;
+};
+
+const togglePhotoSelection = (id) => {
+  photoStore.togglePhotoSelection(id);
+};
+
+const clearSelection = () => {
+  photoStore.selectedPhotoIds = [];
+};
+
+const showPhotoInfo = (photo) => {
+  // TODO: Implement photo info dialog
+};
+
+const moveToCanvas = async () => {
+  await Promise.all(
+    photoStore.selectedPhotoIds.map((id) => photoStore.fetchPhoto(id)),
+  );
+  const photosToAdd = photoStore.selectedPhotoIds
+    .map((id) => photoStore.photos.find((p) => p.id == id))
+    .filter(Boolean);
+
+  photoStore.selectedPhotosRecord = {};
+  canvasStore.addPhotos(photosToAdd);
+
+  router.push("/canvas");
+};
+
+const clearSearch = () => {
+  currentSearchParams.value = {};
+  hasMoreIterations.value = false;
+  iteration.value = 1;
+  iterationsRecord = {};
+  isToolbarCollapsed.value = false;
+  lastScrollY.value = 0;
+};
+
+const performSearch = async (searchParams) => {
+  clearSelection();
+  currentSearchParams.value = searchParams;
+  iteration.value = 1;
+  Object.keys(iterationsRecord).forEach((k) => delete iterationsRecord[k]);
+  isSearching.value = true;
+  hasMoreIterations.value = false;
+
+  await searchPhotos();
+  isSearching.value = false;
+};
+
+const loadMorePhotos = async () => {
+  isLoadingMore.value = true;
+  await searchPhotos();
+  isLoadingMore.value = false;
+};
+
+const searchPhotos = async () => {
+  try {
+    const options = {
+      iteration: iteration.value,
+      pageSize: pageSize.value,
+      searchMode: "logical",
+    };
+
+    const payload = {
+      ...currentSearchParams.value,
+      options,
+    };
+
+    await axios.post(
+      `${import.meta.env.VITE_API_BASE_URL}/api/search/style`,
+      payload,
+    );
+  } catch (err) {
+    console.error("Error al buscar fotos por estilo:", err);
+  }
+};
+
+// Scroll handling
+const handleScroll = () => {
+  if (!scrollContainer.value) return;
+
+  const currentScrollY = scrollContainer.value.scrollTop;
+
+  if (searchResults.value.length > 0 && !isSearching.value) {
+    if (currentScrollY > lastScrollY.value && currentScrollY > 100) {
+      isToolbarCollapsed.value = true;
+    } else if (currentScrollY < lastScrollY.value && currentScrollY < 500) {
+      isToolbarCollapsed.value = false;
+    }
+  } else {
+    isToolbarCollapsed.value = false;
+  }
+
+  lastScrollY.value = currentScrollY;
+};
+
+const scrollToLast = () => {
+  nextTick(() => {
+    const el = scrollContainer.value;
+    if (el) {
+      el.scrollTo({ top: el.scrollHeight, behavior: "smooth" });
+    }
+  });
+};
+
+onMounted(() => {
+  nextTick(() => {
+    if (scrollContainer.value) {
+      scrollContainer.value.addEventListener("scroll", handleScroll, {
+        passive: true,
+      });
+    }
+  });
+
+  socket.on("styleMatches", (data) => {
+    Object.entries(data.results).forEach(([iter, items]) => {
+      iterationsRecord[iter] = {
+        photos: items.map((i) => i.photo),
+      };
+    });
+    hasMoreIterations.value = data.hasMore;
+    iteration.value = data.iteration + 1;
+    setTimeout(() => {
+      scrollToLast();
+    }, 0);
+  });
+});
+
+onUnmounted(() => {
+  if (scrollContainer.value) {
+    scrollContainer.value.removeEventListener("scroll", handleScroll);
+  }
+  socket.off("styleMatches");
+});
+</script>
+
+<style scoped>
+.styler-container {
+  display: flex;
+  flex-direction: column;
+  overflow-y: auto;
+}
+
+/* Styler Toolbar */
+.styler-toolbar {
+  background-color: #18181c;
+  border: 1px solid #2c2c32;
+  border-radius: 16px;
+  padding: 24px;
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  transform: translateY(0);
+  transition: transform 0.3s ease;
+}
+
+.styler-toolbar.is-collapsed {
+  transform: translateY(-120%);
+}
+
+/* Styler Tabs */
+.styler-tabs {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+/* Tab Navigation */
+.tab-navigation {
+  display: flex;
+  background-color: transparent;
+  gap: 8px;
+  justify-content: center;
+  margin-bottom: 16px;
+  padding-bottom: 16px;
+  border-bottom: 1px solid #2c2c32;
+}
+
+.tab-button {
+  flex: 1;
+  max-width: 200px;
+  padding: 12px 24px;
+  background-color: transparent;
+  border: 1px solid #2c2c32;
+  border-radius: 20px;
+  color: #ffffff73;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+  text-align: center;
+}
+
+.tab-button:hover {
+  border-color: #2563eb;
+  color: #ffffffd1;
+  transform: translateY(-1px);
+}
+
+.tab-button.active {
+  background-color: #2563eb;
+  border-color: #2563eb;
+  color: #ffffff;
+  transform: translateY(-1px);
+  box-shadow: 0 4px 8px rgba(37, 99, 235, 0.3);
+}
+
+/* Tab Content Container */
+.tab-content-container {
+  min-height: 120px;
+}
+
+/* Search Results Container */
+.search-results-container {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  padding: 16px;
+  min-height: 0;
+}
+
+/* Search Inspiration */
+.search-inspiration {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex: 1;
+  text-align: center;
+  position: relative;
+  z-index: 1;
+  padding: var(--spacing-2xl) 0;
+}
+
+.inspiration-content {
+  max-width: 600px;
+  position: relative;
+  z-index: 2;
+}
+
+.inspiration-icon {
+  margin-bottom: var(--spacing-lg);
+}
+
+.examples-title {
+  font-size: 20px;
+  font-weight: 600;
+  color: #ffffffd1;
+  margin: 0;
+  text-align: center;
+}
+
+/* Search Loading */
+.search-loading {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+.loading-message {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 0;
+  gap: 16px;
+}
+
+.loading-text {
+  font-size: 16px;
+  color: #ffffff73;
+  margin: 0;
+}
+
+/* Search Results */
+.search-results {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Grid Controls */
+.grid-controls.grid-controls-base {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 20px;
+  padding: 16px 0;
+}
+
+.results-info.results-info-base {
+  flex: 1;
+}
+
+.results-count.results-count-base {
+  font-size: 16px;
+  font-weight: 500;
+  color: #ffffffd1;
+}
+
+.grid-size-controls.grid-size-controls-base {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.grid-label.grid-label-base {
+  font-size: 14px;
+  color: #ffffff73;
+  font-weight: 500;
+}
+
+/* Photo Grid */
+.photo-grid.photo-grid-base {
+  display: grid;
+  gap: 16px;
+  margin-bottom: 24px;
+}
+
+.photo-grid.grid-cols-3 {
+  grid-template-columns: repeat(3, 1fr);
+}
+
+.photo-grid.grid-cols-4 {
+  grid-template-columns: repeat(4, 1fr);
+}
+
+.photo-grid.grid-cols-5 {
+  grid-template-columns: repeat(5, 1fr);
+}
+
+.photo-grid.grid-cols-6 {
+  grid-template-columns: repeat(6, 1fr);
+}
+
+.photo-skeleton {
+  aspect-ratio: 1;
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+/* Selection Info */
+.selection-info {
+  position: fixed;
+  bottom: 30px;
+  right: 41px;
+  background-color: #2563eb;
+  color: #ffffff;
+  padding: 12px 24px;
+  border-radius: 24px;
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  box-shadow: 0 8px 24px rgba(37, 99, 235, 0.4);
+  z-index: 100;
+  font-weight: 500;
+}
+
+.selection-info span {
+  font-size: 14px;
+}
+
+/* Load More */
+.load-more-container {
+  display: flex;
+  justify-content: center;
+  margin-bottom: 32px;
+}
+
+.load-more-button {
+  min-width: 100%;
+  height: 48px;
+  font-size: 16px;
+  font-weight: 500;
+}
+
+/* Mobile Responsive */
+@media (max-width: 768px) {
+  .styler-toolbar {
+    padding: 16px;
+  }
+
+  .tab-navigation {
+    gap: 4px;
+  }
+
+  .tab-button {
+    font-size: 12px;
+    padding: 10px 16px;
+  }
+
+  .photo-grid.grid-cols-3,
+  .photo-grid.grid-cols-4,
+  .photo-grid.grid-cols-5,
+  .photo-grid.grid-cols-6 {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .grid-controls.grid-controls-base {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 12px;
+  }
+
+  .selection-info {
+    bottom: 16px;
+    left: 16px;
+    right: 16px;
+    transform: none;
+    border-radius: 16px;
+  }
+}
+
+@media (max-width: 480px) {
+  .styler-toolbar {
+    padding: 12px;
+  }
+
+  .tab-navigation {
+    flex-direction: column;
+    gap: 8px;
+  }
+
+  .tab-button {
+    max-width: none;
+    font-size: 11px;
+    padding: 8px 12px;
+  }
+
+  .photo-grid.grid-cols-3,
+  .photo-grid.grid-cols-4,
+  .photo-grid.grid-cols-5,
+  .photo-grid.grid-cols-6 {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/src/views/StylerView.vue
+++ b/src/views/StylerView.vue
@@ -431,8 +431,8 @@ onUnmounted(() => {
   background-color: transparent;
   gap: 8px;
   justify-content: center;
-  margin-bottom: 16px;
-  padding-bottom: 16px;
+  margin-bottom: 12px;
+  padding-bottom: 12px;
   border-bottom: 1px solid var(--border-color);
 }
 

--- a/src/views/StylerView.vue
+++ b/src/views/StylerView.vue
@@ -467,7 +467,7 @@ onUnmounted(() => {
 
 /* Tab Content Container */
 .tab-content-container {
-  min-height: 120px;
+  min-height: 80px;
 }
 
 /* Search Results Container */

--- a/src/views/StylerView.vue
+++ b/src/views/StylerView.vue
@@ -406,7 +406,7 @@ onUnmounted(() => {
   background-color: var(--bg-card);
   border: 1px solid var(--border-color);
   border-radius: 16px;
-  padding: 24px;
+  padding: 20px;
   position: sticky;
   top: 0;
   z-index: 10;

--- a/src/views/StylerView.vue
+++ b/src/views/StylerView.vue
@@ -433,7 +433,7 @@ onUnmounted(() => {
   justify-content: center;
   margin-bottom: 16px;
   padding-bottom: 16px;
-  border-bottom: 1px solid #2c2c32;
+  border-bottom: 1px solid var(--border-color);
 }
 
 .tab-button {

--- a/src/views/StylerView.vue
+++ b/src/views/StylerView.vue
@@ -441,9 +441,9 @@ onUnmounted(() => {
   max-width: 200px;
   padding: 12px 24px;
   background-color: transparent;
-  border: 1px solid #2c2c32;
+  border: 1px solid var(--border-color);
   border-radius: 20px;
-  color: #ffffff73;
+  color: var(--text-secondary);
   font-size: 14px;
   font-weight: 500;
   cursor: pointer;
@@ -452,14 +452,14 @@ onUnmounted(() => {
 }
 
 .tab-button:hover {
-  border-color: #2563eb;
-  color: #ffffffd1;
+  border-color: var(--primary-color);
+  color: var(--text-primary);
   transform: translateY(-1px);
 }
 
 .tab-button.active {
-  background-color: #2563eb;
-  border-color: #2563eb;
+  background-color: var(--primary-color);
+  border-color: var(--primary-color);
   color: #ffffff;
   transform: translateY(-1px);
   box-shadow: 0 4px 8px rgba(37, 99, 235, 0.3);

--- a/src/views/StylerView.vue
+++ b/src/views/StylerView.vue
@@ -422,7 +422,7 @@ onUnmounted(() => {
 .styler-tabs {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
 }
 
 /* Tab Navigation */

--- a/src/views/StylerView.vue
+++ b/src/views/StylerView.vue
@@ -403,8 +403,8 @@ onUnmounted(() => {
 
 /* Styler Toolbar */
 .styler-toolbar {
-  background-color: #18181c;
-  border: 1px solid #2c2c32;
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
   border-radius: 16px;
   padding: 24px;
   position: sticky;

--- a/src/views/StylerView.vue
+++ b/src/views/StylerView.vue
@@ -198,7 +198,9 @@ import { usePhotosStore } from "@/stores/photos";
 import { useCanvasStore } from "@/stores/canvas.js";
 import { useRouter } from "vue-router";
 
-const socket = io(import.meta.env.VITE_API_WS_URL);
+const socket = import.meta.env.VITE_API_WS_URL
+  ? io(import.meta.env.VITE_API_WS_URL)
+  : null;
 
 const photoStore = usePhotosStore();
 const canvasStore = useCanvasStore();

--- a/src/views/StylerView.vue
+++ b/src/views/StylerView.vue
@@ -368,18 +368,20 @@ onMounted(() => {
     }
   });
 
-  socket.on("styleMatches", (data) => {
-    Object.entries(data.results).forEach(([iter, items]) => {
-      iterationsRecord[iter] = {
-        photos: items.map((i) => i.photo),
-      };
+  if (socket) {
+    socket.on("styleMatches", (data) => {
+      Object.entries(data.results).forEach(([iter, items]) => {
+        iterationsRecord[iter] = {
+          photos: items.map((i) => i.photo),
+        };
+      });
+      hasMoreIterations.value = data.hasMore;
+      iteration.value = data.iteration + 1;
+      setTimeout(() => {
+        scrollToLast();
+      }, 0);
     });
-    hasMoreIterations.value = data.hasMore;
-    iteration.value = data.iteration + 1;
-    setTimeout(() => {
-      scrollToLast();
-    }, 0);
-  });
+  }
 });
 
 onUnmounted(() => {

--- a/src/views/StylerView.vue
+++ b/src/views/StylerView.vue
@@ -504,7 +504,7 @@ onUnmounted(() => {
 .examples-title {
   font-size: 20px;
   font-weight: 600;
-  color: #ffffffd1;
+  color: var(--text-primary);
   margin: 0;
   text-align: center;
 }

--- a/src/views/StylerView.vue
+++ b/src/views/StylerView.vue
@@ -388,7 +388,9 @@ onUnmounted(() => {
   if (scrollContainer.value) {
     scrollContainer.value.removeEventListener("scroll", handleScroll);
   }
-  socket.off("styleMatches");
+  if (socket) {
+    socket.off("styleMatches");
+  }
 });
 </script>
 


### PR DESCRIPTION
This commit adds a new Styler component to the dashboard with two main tabs:

**Dashboard Sidebar Changes:**
- Import ColorPaletteOutline icon as StylerIcon
- Add new "Styler" menu item to secondSectionOptions with proper disabled state and icon

**New Components:**
- **ExplorerTab.vue**: Allows users to select aesthetic characteristics using checkable tags and explore photos based on selected aspects
- **RankingTab.vue**: Provides sliders for distributing 100 points across aesthetic aspects to rank photo preferences
- **StylerView.vue**: Main container component with tab navigation, search functionality, photo grid display, and selection management

**Key Features:**
- Tab-based interface with Ranking and Explorer modes
- Aesthetic aspects selection (reflections, lighting, symmetry, etc.)
- Photo search and grid display with responsive design
- Photo selection and canvas integration
- Socket.io integration for real-time search results
- Mobile-responsive layout with collapsible toolbar

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 29`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e7707f36ee004767b325d7c562f1c2bb/quantum-oasis)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e7707f36ee004767b325d7c562f1c2bb</projectId>-->
<!--<branchName>quantum-oasis</branchName>-->