### PR TITLE
Add floating add photos button component

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -45,10 +45,10 @@
             </div>
           </div>
         </div>
-      </template>
 
-      <!-- Floating Add Photos Button -->
-      <FloatingAddPhotosButton />
+        <!-- Floating Add Photos Button -->
+        <FloatingAddPhotosButton />
+      </template>
     </n-message-provider>
   </n-config-provider>
 </template>

--- a/src/App.vue
+++ b/src/App.vue
@@ -46,6 +46,9 @@
           </div>
         </div>
       </template>
+
+      <!-- Floating Add Photos Button -->
+      <FloatingAddPhotosButton />
     </n-message-provider>
   </n-config-provider>
 </template>
@@ -57,6 +60,7 @@ import { darkTheme } from "naive-ui";
 import { useUserStore } from "./stores/userStore";
 import DashboardSidebar from "./components/DashboardSidebar.vue";
 import DashboardHeader from "./components/DashboardHeader.vue";
+import FloatingAddPhotosButton from "./components/FloatingAddPhotosButton.vue";
 import { usePhotosStore } from "@/stores/photos.js";
 
 const photosStore = usePhotosStore();
@@ -154,9 +158,9 @@ onUnmounted(() => {
 <style>
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
-    "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",
-    sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
+    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   background-color: #101014;

--- a/src/components/FloatingAddPhotosButton.vue
+++ b/src/components/FloatingAddPhotosButton.vue
@@ -9,9 +9,7 @@
   >
     <template #icon>
       <n-icon size="24">
-        <svg viewBox="0 0 24 24">
-          <path fill="currentColor" d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
-        </svg>
+        <ImagesOutline />
       </n-icon>
     </template>
   </n-button>
@@ -20,6 +18,7 @@
 <script setup>
 import { computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
+import { ImagesOutline } from "@vicons/ionicons5";
 
 const route = useRoute();
 const router = useRouter();

--- a/src/components/FloatingAddPhotosButton.vue
+++ b/src/components/FloatingAddPhotosButton.vue
@@ -1,27 +1,20 @@
 <template>
-  <Teleport to="body">
-    <Transition name="fab">
-      <n-button
-        v-if="shouldShow"
-        type="primary"
-        size="large"
-        circle
-        class="floating-add-button"
-        @click="handleClick"
-      >
-        <template #icon>
-          <n-icon size="24">
-            <svg viewBox="0 0 24 24">
-              <path
-                fill="currentColor"
-                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
-              />
-            </svg>
-          </n-icon>
-        </template>
-      </n-button>
-    </Transition>
-  </Teleport>
+  <n-button
+    v-if="shouldShow"
+    type="primary"
+    size="large"
+    circle
+    class="floating-add-button"
+    @click="handleClick"
+  >
+    <template #icon>
+      <n-icon size="24">
+        <svg viewBox="0 0 24 24">
+          <path fill="currentColor" d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z" />
+        </svg>
+      </n-icon>
+    </template>
+  </n-button>
 </template>
 
 <script setup>
@@ -45,15 +38,14 @@ const handleClick = async () => {
   await router.push("/photo-hub#upload");
 
   // Esperar un tick para que se renderice la vista
-  await new Promise((resolve) => setTimeout(resolve, 100));
-
-  // Triggear el click del botón "Choose Files" en PhotosUpload
-  const chooseFilesButton = document.querySelector(
-    ".upload-btn, .compact-upload-btn",
-  );
-  if (chooseFilesButton) {
-    chooseFilesButton.click();
-  }
+  setTimeout(() => {
+    const chooseFilesButton = document.querySelector(
+      ".upload-btn, .compact-upload-btn",
+    );
+    if (chooseFilesButton) {
+      chooseFilesButton.click();
+    }
+  }, 200);
 };
 </script>
 

--- a/src/components/FloatingAddPhotosButton.vue
+++ b/src/components/FloatingAddPhotosButton.vue
@@ -1,0 +1,102 @@
+<template>
+  <Teleport to="body">
+    <Transition name="fab">
+      <n-button
+        v-if="shouldShow"
+        type="primary"
+        size="large"
+        circle
+        class="floating-add-button"
+        @click="handleClick"
+      >
+        <template #icon>
+          <n-icon size="24">
+            <svg viewBox="0 0 24 24">
+              <path
+                fill="currentColor"
+                d="M19 13h-6v6h-2v-6H5v-2h6V5h2v6h6v2z"
+              />
+            </svg>
+          </n-icon>
+        </template>
+      </n-button>
+    </Transition>
+  </Teleport>
+</template>
+
+<script setup>
+import { computed } from "vue";
+import { useRoute, useRouter } from "vue-router";
+
+const route = useRoute();
+const router = useRouter();
+
+// Define las rutas donde NO debe aparecer el botón
+const hiddenRoutes = ["canvas", "grid-maker"];
+
+// Calcular si el botón debe mostrarse
+const shouldShow = computed(() => {
+  return !hiddenRoutes.includes(route.name);
+});
+
+// Manejar click del botón
+const handleClick = async () => {
+  // Navegar a photo-hub con el hash para la pestaña upload
+  await router.push("/photo-hub#upload");
+
+  // Esperar un tick para que se renderice la vista
+  await new Promise((resolve) => setTimeout(resolve, 100));
+
+  // Triggear el click del botón "Choose Files" en PhotosUpload
+  const chooseFilesButton = document.querySelector(
+    ".upload-btn, .compact-upload-btn",
+  );
+  if (chooseFilesButton) {
+    chooseFilesButton.click();
+  }
+};
+</script>
+
+<style scoped>
+.floating-add-button {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 1000;
+  width: 56px;
+  height: 56px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  backdrop-filter: blur(8px);
+}
+
+.floating-add-button:hover {
+  transform: scale(1.05);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+}
+
+/* Transiciones */
+.fab-enter-active,
+.fab-leave-active {
+  transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.fab-enter-from {
+  opacity: 0;
+  transform: scale(0.8) translateY(20px);
+}
+
+.fab-leave-to {
+  opacity: 0;
+  transform: scale(0.8) translateY(20px);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+  .floating-add-button {
+    bottom: 16px;
+    right: 16px;
+    width: 48px;
+    height: 48px;
+  }
+}
+</style>


### PR DESCRIPTION
Add new FloatingAddPhotosButton component that provides quick access to photo upload functionality.

Changes:
- Create new FloatingAddPhotosButton.vue component with circular floating action button
- Add component to main App.vue template and import
- Button appears on all routes except 'canvas' and 'grid-maker'
- Clicking button navigates to photo-hub upload tab and triggers file chooser
- Include responsive design for mobile devices
- Add hover effects and smooth transitions
- Update PhotosUpload.vue fast mode logic to be smarter about first-time uploads
- Minor code formatting improvements in App.vue font-family CSS

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 34`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e7707f36ee004767b325d7c562f1c2bb/orbit-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e7707f36ee004767b325d7c562f1c2bb</projectId>-->
<!--<branchName>orbit-haven</branchName>-->