### PR TITLE
Replace tag filter with text search in PhotosDialog

### DIFF
--- a/src/components/canvas/PhotosDialog.vue
+++ b/src/components/canvas/PhotosDialog.vue
@@ -273,27 +273,11 @@ const canvasStore = useCanvasStore();
 const selectedIds = ref([]);
 const syncSelectedIds = ref([]);
 const isSubmitting = ref(false);
-const selectedTags = ref([]);
+const searchQuery = ref("");
 const activeTab = ref("catalog");
-
-// Tag options for search (mock data)
-const tagOptions = [
-  { label: "landscape", value: "landscape" },
-  { label: "portrait", value: "portrait" },
-  { label: "nature", value: "nature" },
-  { label: "architecture", value: "architecture" },
-  { label: "people", value: "people" },
-  { label: "animals", value: "animals" },
-  { label: "food", value: "food" },
-  { label: "travel", value: "travel" },
-  { label: "street", value: "street" },
-  { label: "black & white", value: "black_white" },
-  { label: "macro", value: "macro" },
-  { label: "sunset", value: "sunset" },
-  { label: "urban", value: "urban" },
-  { label: "vintage", value: "vintage" },
-  { label: "minimalist", value: "minimalist" },
-];
+const isSearching = ref(false);
+const searchResults = ref([]);
+const allCatalogPhotos = ref([]);
 
 // Computed photos for different contexts
 const catalogPhotos = computed(() => {

--- a/src/components/canvas/PhotosDialog.vue
+++ b/src/components/canvas/PhotosDialog.vue
@@ -23,17 +23,26 @@
             <!-- Search and Stats Bar -->
             <div class="stats-bar">
               <div class="search-section">
-                <n-select
-                  v-model:value="selectedTags"
-                  multiple
-                  filterable
-                  placeholder="Filter by tags..."
-                  :options="tagOptions"
+                <n-input
+                  v-model:value="searchQuery"
+                  placeholder="Search photos..."
                   size="small"
                   clearable
-                  :max-tag-count="3"
-                  class="tag-search"
-                />
+                  class="text-search"
+                  @input="onSearchChange"
+                  @clear="clearSearch"
+                >
+                  <template #prefix>
+                    <n-icon size="16">
+                      <svg viewBox="0 0 24 24">
+                        <path
+                          fill="currentColor"
+                          d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5A6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5S14 7.01 14 9.5S11.99 14 9.5 14z"
+                        />
+                      </svg>
+                    </n-icon>
+                  </template>
+                </n-input>
               </div>
               <div class="stats-section">
                 <div class="stats-info">

--- a/src/components/canvas/PhotosDialog.vue
+++ b/src/components/canvas/PhotosDialog.vue
@@ -281,8 +281,20 @@ const allCatalogPhotos = ref([]);
 
 // Computed photos for different contexts
 const catalogPhotos = computed(() => {
-  // Return photos that are not on canvas and not discarded
-  return photosStore.catalogPhotos.filter(
+  // If there's a search query and we have search results, use them
+  if (searchQuery.value.trim() && searchResults.value.length > 0) {
+    return searchResults.value.filter(
+      (p) =>
+        !canvasStore.photos.find((photo) => photo.id === p.id) &&
+        !canvasStore.discardedPhotos.find((photo) => photo.id === p.id),
+    );
+  }
+
+  // Otherwise, return all available photos (filtered or unfiltered)
+  const photosToShow = searchQuery.value.trim()
+    ? searchResults.value
+    : allCatalogPhotos.value;
+  return photosToShow.filter(
     (p) =>
       !canvasStore.photos.find((photo) => photo.id === p.id) &&
       !canvasStore.discardedPhotos.find((photo) => photo.id === p.id),

--- a/src/components/canvas/PhotosDialog.vue
+++ b/src/components/canvas/PhotosDialog.vue
@@ -246,7 +246,8 @@ import { usePhotosStore } from "@/stores/photos";
 import { useCanvasStore } from "@/stores/canvas";
 import PhotoCard from "@/components/photoCards/PhotoCard.vue";
 import PhotosSyncTab from "./PhotosSyncTab.vue";
-import { NModal, NButton, NIcon, NSelect, NTabs, NTabPane } from "naive-ui";
+import { NModal, NButton, NIcon, NInput, NTabs, NTabPane } from "naive-ui";
+import axios from "axios";
 
 // Import @vicons icons from ionicons5 for reliability
 import {

--- a/src/components/canvas/PhotosDialog.vue
+++ b/src/components/canvas/PhotosDialog.vue
@@ -729,7 +729,7 @@ onUnmounted(() => {
     font-size: var(--font-size-lg);
   }
 
-  .tag-search {
+  .text-search {
     max-width: none;
   }
 }

--- a/src/components/canvas/PhotosDialog.vue
+++ b/src/components/canvas/PhotosDialog.vue
@@ -301,8 +301,8 @@ const allCatalogPhotos = ref([]);
 
 // Computed photos for different contexts
 const catalogPhotos = computed(() => {
-  // If there's a search query and we have search results, use them
-  if (searchQuery.value.trim() && searchResults.value.length > 0) {
+  // If there's a search query, use search results (even if empty - means no matches)
+  if (searchQuery.value.trim()) {
     return searchResults.value.filter(
       (p) =>
         !canvasStore.photos.find((photo) => photo.id === p.id) &&
@@ -310,15 +310,8 @@ const catalogPhotos = computed(() => {
     );
   }
 
-  // Otherwise, return all available photos (filtered or unfiltered)
-  const photosToShow = searchQuery.value.trim()
-    ? searchResults.value
-    : allCatalogPhotos.value;
-  return photosToShow.filter(
-    (p) =>
-      !canvasStore.photos.find((photo) => photo.id === p.id) &&
-      !canvasStore.discardedPhotos.find((photo) => photo.id === p.id),
-  );
+  // No search query, show all available photos
+  return allCatalogPhotos.value;
 });
 
 const trashPhotos = computed(() => {

--- a/src/components/canvas/PhotosDialog.vue
+++ b/src/components/canvas/PhotosDialog.vue
@@ -500,13 +500,22 @@ function clearSearch() {
 // Watch for dialog open/close to fetch photos
 watch(
   () => props.modelValue,
-  (isOpen) => {
+  async (isOpen) => {
     if (isOpen) {
       selectedIds.value = [];
       syncSelectedIds.value = [];
       activeTab.value = "catalog";
+      clearSearch();
+
       // Ensure photos are loaded
-      photosStore.getOrFetch();
+      await photosStore.getOrFetch();
+
+      // Initialize all catalog photos for search filtering
+      allCatalogPhotos.value = photosStore.catalogPhotos.filter(
+        (p) =>
+          !canvasStore.photos.find((photo) => photo.id === p.id) &&
+          !canvasStore.discardedPhotos.find((photo) => photo.id === p.id),
+      );
     }
   },
 );

--- a/src/components/canvas/PhotosDialog.vue
+++ b/src/components/canvas/PhotosDialog.vue
@@ -521,9 +521,31 @@ watch(
   },
 );
 
+// Socket for real-time search results
+const socket = io(import.meta.env.VITE_API_WS_URL);
+
 // Fetch photos on mount
 onMounted(() => {
   photosStore.getOrFetch();
+
+  // Listen for search results
+  socket.on("matches", (data) => {
+    if (isSearching.value) {
+      // Extract photos from search results
+      const photos = [];
+      Object.entries(data.results).forEach(([iter, items]) => {
+        photos.push(...items.map((i) => i.photo));
+      });
+
+      searchResults.value = photos;
+      isSearching.value = false;
+    }
+  });
+});
+
+onUnmounted(() => {
+  socket.off("matches");
+  socket.disconnect();
 });
 </script>
 

--- a/src/components/canvas/PhotosDialog.vue
+++ b/src/components/canvas/PhotosDialog.vue
@@ -241,13 +241,14 @@
 </template>
 
 <script setup>
-import { ref, computed, onMounted, watch } from "vue";
+import { ref, computed, onMounted, onUnmounted, watch } from "vue";
 import { usePhotosStore } from "@/stores/photos";
 import { useCanvasStore } from "@/stores/canvas";
 import PhotoCard from "@/components/photoCards/PhotoCard.vue";
 import PhotosSyncTab from "./PhotosSyncTab.vue";
 import { NModal, NButton, NIcon, NInput, NTabs, NTabPane } from "naive-ui";
 import axios from "axios";
+import { io } from "socket.io-client";
 
 // Import @vicons icons from ionicons5 for reliability
 import {

--- a/src/components/canvas/PhotosDialog.vue
+++ b/src/components/canvas/PhotosDialog.vue
@@ -594,7 +594,7 @@ onUnmounted(() => {
   min-width: 200px;
 }
 
-.tag-search {
+.text-search {
   width: 100%;
   max-width: 300px;
 }

--- a/src/components/canvas/PhotosDialog.vue
+++ b/src/components/canvas/PhotosDialog.vue
@@ -123,17 +123,26 @@
         <!-- Search and Stats Bar -->
         <div class="stats-bar">
           <div class="search-section">
-            <n-select
-              v-model:value="selectedTags"
-              multiple
-              filterable
-              placeholder="Filter by tags..."
-              :options="tagOptions"
+            <n-input
+              v-model:value="searchQuery"
+              placeholder="Search photos..."
               size="small"
               clearable
-              :max-tag-count="3"
-              class="tag-search"
-            />
+              class="text-search"
+              @input="onSearchChange"
+              @clear="clearSearch"
+            >
+              <template #prefix>
+                <n-icon size="16">
+                  <svg viewBox="0 0 24 24">
+                    <path
+                      fill="currentColor"
+                      d="M15.5 14h-.79l-.28-.27A6.471 6.471 0 0 0 16 9.5A6.5 6.5 0 1 0 9.5 16c1.61 0 3.09-.59 4.23-1.57l.27.28v.79l5 4.99L20.49 19l-4.99-5zm-6 0C7.01 14 5 11.99 5 9.5S7.01 5 9.5 5S14 7.01 14 9.5S11.99 14 9.5 14z"
+                    />
+                  </svg>
+                </n-icon>
+              </template>
+            </n-input>
           </div>
           <div class="stats-section">
             <div class="stats-info">


### PR DESCRIPTION
Replace the tag-based filtering system with a text search functionality in PhotosDialog.vue.

Changes made:
- Replaced n-select tag filter with n-input text search component
- Added search icon prefix to the input field
- Implemented debounced search with 500ms timeout
- Added semantic search API integration using axios
- Added socket.io connection for real-time search results
- Updated imports to include NInput, axios, and socket.io-client
- Removed NSelect from imports and tag-related data/options
- Added search state management (isSearching, searchResults, allCatalogPhotos)
- Updated computed catalogPhotos to handle search results vs all photos
- Added onSearchChange, performSearch, and clearSearch methods
- Added socket listener for "matches" events
- Updated CSS classes from "tag-search" to "text-search"
- Added proper cleanup in onUnmounted hook

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 36`

🔗 [Edit in Builder.io](https://builder.io/app/projects/e7707f36ee004767b325d7c562f1c2bb/swoosh-haven)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>e7707f36ee004767b325d7c562f1c2bb</projectId>-->
<!--<branchName>swoosh-haven</branchName>-->